### PR TITLE
ci: setup java 17 for libcore

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           go-version: ${{ steps.version.outputs.go_version }}
           cache-dependency-path: libcore/go.sum
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
       - name: Native Build
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
         with:
           go-version: ${{ steps.version.outputs.go_version }}
           cache-dependency-path: libcore/go.sum
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
       - name: Native Build
         if: steps.cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
About #1 

Now you can build the same libcore as action. But you should use the same Go version and gomobile.