### PR TITLE
fix: UI issue of add_profile_menu and traffic_menu on low DPIs

### DIFF
--- a/app/src/main/res/menu/add_profile_menu.xml
+++ b/app/src/main/res/menu/add_profile_menu.xml
@@ -11,7 +11,7 @@
             android:id="@+id/action_add"
             android:icon="@drawable/ic_action_note_add"
             android:title="@string/add_profile"
-            app:showAsAction="ifRoom">
+            app:showAsAction="always">
         <menu>
             <item
                     android:id="@+id/action_scan_qr_code"
@@ -81,55 +81,54 @@
     </item>
 
     <item
-            android:id="@+id/action_misc"
-            android:icon="@drawable/ic_baseline_more_vert_24"
-            android:title=""
-            app:showAsAction="always">
+            android:id="@+id/action_clear_traffic_statistics"
+            android:title="@string/clear_traffic_statistics"
+            app:showAsAction="never"/>
+
+    <item
+            android:id="@+id/action_remove_duplicate"
+            android:title="@string/remove_duplicate"
+            app:showAsAction="never"/>
+
+    <item
+            android:id="@+id/action_connection_test"
+            android:title="@string/connection_test"
+            app:showAsAction="never">
         <menu>
             <item
-                    android:id="@+id/action_clear_traffic_statistics"
-                    android:title="@string/clear_traffic_statistics" />
+                    android:id="@+id/action_connection_icmp_ping"
+                    android:title="@string/connection_test_icmp_ping" />
             <item
-                    android:id="@+id/action_remove_duplicate"
-                    android:title="@string/remove_duplicate" />
+                    android:id="@+id/action_connection_tcp_ping"
+                    android:title="@string/connection_test_tcp_ping" />
             <item
-                    android:id="@+id/action_connection_test"
-                    android:title="@string/connection_test">
-                <menu>
-                    <item
-                            android:id="@+id/action_connection_icmp_ping"
-                            android:title="@string/connection_test_icmp_ping" />
-                    <item
-                            android:id="@+id/action_connection_tcp_ping"
-                            android:title="@string/connection_test_tcp_ping" />
-                    <item
-                            android:id="@+id/action_connection_url_test"
-                            android:title="@string/connection_test_url_test" />
-                    <item
-                            android:id="@+id/action_connection_test_clear_results"
-                            android:title="@string/connection_test_clear_results" />
-                    <item
-                            android:id="@+id/action_connection_test_delete_unavailable"
-                            android:title="@string/connection_test_delete_unavailable" />
-                </menu>
-            </item>
+                    android:id="@+id/action_connection_url_test"
+                    android:title="@string/connection_test_url_test" />
             <item
-                    android:id="@+id/action_order"
-                    android:title="@string/group_order">
-                <menu>
-                    <group android:checkableBehavior="single">
-                        <item
-                                android:id="@+id/action_order_origin"
-                                android:title="@string/group_order_origin" />
-                        <item
-                                android:id="@+id/action_order_by_name"
-                                android:title="@string/group_order_by_name" />
-                        <item
-                                android:id="@+id/action_order_by_delay"
-                                android:title="@string/group_order_by_delay" />
-                    </group>
-                </menu>
-            </item>
+                    android:id="@+id/action_connection_test_clear_results"
+                    android:title="@string/connection_test_clear_results" />
+            <item
+                    android:id="@+id/action_connection_test_delete_unavailable"
+                    android:title="@string/connection_test_delete_unavailable" />
+        </menu>
+    </item>
+
+    <item
+            android:id="@+id/action_order"
+            android:title="@string/group_order"
+            app:showAsAction="never">
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                        android:id="@+id/action_order_origin"
+                        android:title="@string/group_order_origin" />
+                <item
+                        android:id="@+id/action_order_by_name"
+                        android:title="@string/group_order_by_name" />
+                <item
+                        android:id="@+id/action_order_by_delay"
+                        android:title="@string/group_order_by_delay" />
+            </group>
         </menu>
     </item>
 

--- a/app/src/main/res/menu/traffic_menu.xml
+++ b/app/src/main/res/menu/traffic_menu.xml
@@ -15,60 +15,52 @@
             app:showAsAction="always" />
 
     <item
-            android:id="@+id/action_misc"
-            android:icon="@drawable/ic_baseline_more_vert_24"
-            android:title=""
-            app:showAsAction="ifRoom">
+            android:id="@+id/action_sort"
+            android:title="@string/sort"
+            app:showAsAction="never">
 
         <menu>
-            <item
-                    android:id="@+id/action_sort"
-                    android:title="@string/sort">
-
-                <menu>
-                    <group android:checkableBehavior="single">
-                        <item
-                                android:id="@+id/action_sort_ascending"
-                                android:title="@string/ascending" />
-                        <item
-                                android:id="@+id/action_sort_descending"
-                                android:title="@string/descending" />
-                    </group>
-                </menu>
-            </item>
+            <group android:checkableBehavior="single">
+                <item
+                        android:id="@+id/action_sort_ascending"
+                        android:title="@string/ascending" />
+                <item
+                        android:id="@+id/action_sort_descending"
+                        android:title="@string/descending" />
+            </group>
+        </menu>
+    </item>
 
 
-            <item
-                    android:id="@+id/action_sort_method"
-                    android:title="@string/sort_mode">
+    <item
+            android:id="@+id/action_sort_method"
+            android:title="@string/sort_mode"
+            app:showAsAction="never">
 
-                <menu>
-                    <group android:checkableBehavior="single">
-                        <item
-                                android:id="@+id/action_sort_time"
-                                android:title="@string/by_time" />
-                        <item
-                                android:id="@+id/action_sort_inbound"
-                                android:title="@string/by_inbound" />
-                        <item
-                                android:id="@+id/action_sort_upload"
-                                android:title="@string/by_upload" />
-                        <item
-                                android:id="@+id/action_sort_download"
-                                android:title="@string/by_download" />
-                        <item
-                                android:id="@+id/action_sort_source"
-                                android:title="@string/by_source" />
-                        <item
-                                android:id="@+id/action_sort_destination"
-                                android:title="@string/by_destination" />
-                        <item
-                                android:id="@+id/action_sort_rule"
-                                android:title="@string/by_matched_rule" />
-                    </group>
-                </menu>
-            </item>
-
+        <menu>
+            <group android:checkableBehavior="single">
+                <item
+                        android:id="@+id/action_sort_time"
+                        android:title="@string/by_time" />
+                <item
+                        android:id="@+id/action_sort_inbound"
+                        android:title="@string/by_inbound" />
+                <item
+                        android:id="@+id/action_sort_upload"
+                        android:title="@string/by_upload" />
+                <item
+                        android:id="@+id/action_sort_download"
+                        android:title="@string/by_download" />
+                <item
+                        android:id="@+id/action_sort_source"
+                        android:title="@string/by_source" />
+                <item
+                        android:id="@+id/action_sort_destination"
+                        android:title="@string/by_destination" />
+                <item
+                        android:id="@+id/action_sort_rule"
+                        android:title="@string/by_matched_rule" />
+            </group>
         </menu>
     </item>
 


### PR DESCRIPTION
On low DPIs like 320 dpi, the UI of `add_profile_menu` will be like this:
![Screenshot_20241031-031230](https://github.com/user-attachments/assets/b95be7c2-b8a7-4a13-92b8-0255b6bcbb37)

And BTW you may want to add icons to all options to avoid strange UI like this:

![Screenshot_20241031-031325](https://github.com/user-attachments/assets/a3d61bef-3de7-4cbd-9253-ce56ca46c223)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The "Add" action is now always visible in the action bar for easier access.
	- Introduced new menu items for clearing traffic statistics, removing duplicates, and connection testing.
	- Enhanced connection test options with new sub-items for various testing methods.
	- Added a new sorting action to the traffic menu, integrating sorting options for improved organization.

- **Improvements**
	- Streamlined menu structure for better usability and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->