### PR TITLE
feat(dns): add TCP reuse

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/SingBoxOptions.java
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/SingBoxOptions.java
@@ -2390,6 +2390,56 @@ public class SingBoxOptions {
 
     }
 
+    public static class NewDNSServerOptions_RemoteTCPDNSServerOptions extends NewDNSServerOptions {
+
+        // Generate note: nested type RemoteDNSServerOptions
+        // Generate note: nested type LocalDNSServerOptions
+        // Generate note: nested type DialerOptions
+        public String detour;
+
+        public String bind_interface;
+
+        public String inet4_bind_address;
+
+        public String inet6_bind_address;
+
+        public String protect_path;
+
+        public Integer routing_mark;
+
+        public Boolean reuse_addr;
+
+        public String netns;
+
+        public String connect_timeout;
+
+        public Boolean tcp_fast_open;
+
+        public Boolean tcp_multi_path;
+
+        public Boolean udp_fragment;
+
+        public DomainResolveOptions domain_resolver;
+
+        public String network_strategy;
+
+        public List<String> network_type;
+
+        public List<String> fallback_network_type;
+
+        public String fallback_delay;
+
+        public String domain_strategy;
+
+        // Generate note: nested type DNSServerAddressOptions
+        public String server;
+
+        public Integer server_port;
+
+        public Boolean reuse;
+
+    }
+
     public static class NewDNSServerOptions_RemoteTLSDNSServerOptions extends NewDNSServerOptions {
 
         // Generate note: nested type RemoteDNSServerOptions

--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/SingBoxOptionsUtil.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/SingBoxOptionsUtil.kt
@@ -16,6 +16,7 @@ import io.nekohasekai.sagernet.fmt.SingBoxOptions.RuleSet_Local
 import io.nekohasekai.sagernet.fmt.SingBoxOptions.RuleSet_Remote
 import io.nekohasekai.sagernet.fmt.SingBoxOptions.Rule_Default
 import io.nekohasekai.sagernet.fmt.SingBoxOptions.Rule_Logical
+import io.nekohasekai.sagernet.ktx.parseBoolean
 import libcore.Libcore
 
 fun DNSRule_Default.makeCommonRule(list: List<RuleItem>) {
@@ -283,7 +284,17 @@ fun buildDNSServer(
             detour = out
         }
 
-        // "", SingBoxOptions.DNS_TYPE_UDP, SingBoxOptions.DNS_TYPE_TCP ->
+        SingBoxOptions.DNS_TYPE_TCP -> SingBoxOptions.NewDNSServerOptions_RemoteTCPDNSServerOptions()
+            .apply {
+                type = SingBoxOptions.DNS_TYPE_TCP
+                server = url.host
+                server_port = url.ports.toIntOrNull()
+                domain_resolver = domainResolver
+                detour = out
+                if (url.parseBoolean("reuse")) reuse = true
+            }
+
+        // "", SingBoxOptions.DNS_TYPE_UDP ->
         else -> NewDNSServerOptions_RemoteDNSServerOptions().apply {
             type = scheme.ifBlank {
                 SingBoxOptions.DNS_TYPE_UDP

--- a/libcore/cmd/boxoption/main.go
+++ b/libcore/cmd/boxoption/main.go
@@ -164,6 +164,7 @@ var newDNSServerList = []any{
 	option.HostsDNSServerOptions{},
 	option.LocalDNSServerOptions{},
 	option.RemoteDNSServerOptions{},
+	pluginoption.RemoteTCPDNSServerOptions{},
 	option.RemoteTLSDNSServerOptions{},
 	option.RemoteHTTPSDNSServerOptions{},
 	option.FakeIPDNSServerOptions{},

--- a/libcore/distro/plugin.go
+++ b/libcore/distro/plugin.go
@@ -2,10 +2,16 @@ package distro
 
 import (
 	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/dns"
 
 	"libcore/plugin/http"
+	"libcore/plugin/plugindns"
 )
 
 func registerPluginsOutbound(registry *outbound.Registry) {
 	http.RegisterOutbound(registry)
+}
+
+func registerPluginsDNSTransport(registry *dns.TransportRegistry) {
+	plugindns.RegisterTCP(registry)
 }

--- a/libcore/distro/registry.go
+++ b/libcore/distro/registry.go
@@ -112,7 +112,7 @@ func registerWireGuardEndpoint(registry *endpoint.Registry) {
 func DNSTransportRegistry() *dns.TransportRegistry {
 	registry := dns.NewTransportRegistry()
 
-	transport.RegisterTCP(registry)
+	// transport.RegisterTCP(registry) // Move to plugin
 	transport.RegisterUDP(registry)
 	transport.RegisterTLS(registry)
 	transport.RegisterHTTPS(registry)
@@ -121,6 +121,8 @@ func DNSTransportRegistry() *dns.TransportRegistry {
 	fakeip.RegisterTransport(registry)
 
 	registerQUICTransports(registry)
+
+	registerPluginsDNSTransport(registry)
 
 	return registry
 }

--- a/libcore/plugin/plugindns/tcp.go
+++ b/libcore/plugin/plugindns/tcp.go
@@ -1,0 +1,126 @@
+package plugindns
+
+import (
+	"context"
+	"net"
+	"sync"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/common/dialer"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/dns"
+	"github.com/sagernet/sing-box/dns/transport"
+	"github.com/sagernet/sing-box/log"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/common/x/list"
+
+	"libcore/plugin/pluginoption"
+
+	mDNS "github.com/miekg/dns"
+)
+
+var _ adapter.DNSTransport = (*TCPTransport)(nil)
+
+func RegisterTCP(registry *dns.TransportRegistry) {
+	dns.RegisterTransport[pluginoption.RemoteTCPDNSServerOptions](registry, C.DNSTypeTCP, NewTCP)
+}
+
+type TCPTransport struct {
+	dns.TransportAdapter
+	dialer      N.Dialer
+	serverAddr  M.Socksaddr
+	access      *sync.Mutex
+	connections *list.List[*reusableConn]
+}
+
+type reusableConn struct {
+	net.Conn
+	queryID uint16
+}
+
+func NewTCP(ctx context.Context, logger log.ContextLogger, tag string, options pluginoption.RemoteTCPDNSServerOptions) (adapter.DNSTransport, error) {
+	transportDialer, err := dns.NewRemoteDialer(ctx, options.RemoteDNSServerOptions)
+	if err != nil {
+		return nil, err
+	}
+	serverAddr := options.DNSServerAddressOptions.Build()
+	if serverAddr.Port == 0 {
+		serverAddr.Port = 53
+	}
+	if !serverAddr.IsValid() {
+		return nil, E.New("invalid server address: ", serverAddr)
+	}
+	transport := &TCPTransport{
+		TransportAdapter: dns.NewTransportAdapterWithRemoteOptions(C.DNSTypeTCP, tag, options.RemoteDNSServerOptions),
+		dialer:           transportDialer,
+		serverAddr:       serverAddr,
+	}
+	if options.Reuse {
+		transport.access = new(sync.Mutex)
+		transport.connections = new(list.List[*reusableConn])
+	}
+	return transport, nil
+}
+
+func (t *TCPTransport) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	return dialer.InitializeDetour(t.dialer)
+}
+
+func (t *TCPTransport) Close() error {
+	if t.access == nil {
+		return nil
+	}
+	t.access.Lock()
+	defer t.access.Unlock()
+	for connection := t.connections.Front(); connection != nil; connection = connection.Next() {
+		_ = connection.Value.Close()
+	}
+	t.connections.Init()
+	return nil
+}
+
+func (t *TCPTransport) Exchange(ctx context.Context, message *mDNS.Msg) (*mDNS.Msg, error) {
+	if t.access != nil {
+		t.access.Lock()
+		conn := t.connections.PopFront()
+		t.access.Unlock()
+		if conn != nil {
+			response, err := t.exchange(message, conn)
+			if err == nil {
+				return response, nil
+			}
+		}
+	}
+	conn, err := t.dialer.DialContext(ctx, N.NetworkTCP, t.serverAddr)
+	if err != nil {
+		return nil, err
+	}
+	return t.exchange(message, &reusableConn{Conn: conn})
+}
+
+func (t *TCPTransport) exchange(message *mDNS.Msg, conn *reusableConn) (*mDNS.Msg, error) {
+	defer func() {
+		conn.queryID++
+	}()
+	err := transport.WriteMessage(conn, conn.queryID, message)
+	if err != nil {
+		_ = conn.Close()
+		return nil, E.Cause(err, "write request")
+	}
+	response, err := transport.ReadMessage(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, E.Cause(err, "read response")
+	}
+	if t.access != nil {
+		t.access.Lock()
+		t.connections.PushBack(conn)
+		t.access.Unlock()
+	}
+	return response, nil
+}

--- a/libcore/plugin/pluginoption/dns.go
+++ b/libcore/plugin/pluginoption/dns.go
@@ -1,0 +1,10 @@
+package pluginoption
+
+import (
+	"github.com/sagernet/sing-box/option"
+)
+
+type RemoteTCPDNSServerOptions struct {
+	option.RemoteDNSServerOptions
+	Reuse bool `json:"reuse,omitempty"`
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for remote TCP DNS servers with detailed configuration options and connection reuse.
  * Introduced a plugin-based TCP DNS transport to improve DNS query performance and management.

* **Improvements**
  * Enhanced DNS server configuration with additional network, dialer, and resolver settings.
  * Updated DNS transport registration to use plugin architecture for TCP DNS support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->