### PR TITLE
fix: prevent app-specific rules from falling back to global rule

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/fmt/ConfigBuilder.kt
@@ -591,7 +591,7 @@ fun buildConfig(
             if (rule.packages.isNotEmpty() && uidList.isEmpty()) {
                 // all packages in the rule are not installed
                 // the rule would be never hit, skipping
-                continue;
+                continue
             }
 
             val ruleObj = Rule_Default().apply {


### PR DESCRIPTION
#375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of user-defined routing rules by skipping rules that reference uninstalled packages, preventing invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->