### PR TITLE
Fix incorrect insets padding

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/tasker/TaskerActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/tasker/TaskerActivity.kt
@@ -74,17 +74,6 @@ class TaskerActivity : ThemedActivity(R.layout.layout_config_settings),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.tasker_settings)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AboutFragment.kt
@@ -48,17 +48,6 @@ class AboutFragment : ToolbarFragment(R.layout.layout_about) {
         binding = LayoutAboutBinding.bind(view)
 
         toolbar.setTitle(R.string.menu_about)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.layoutAbout) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AssetEditActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AssetEditActivity.kt
@@ -104,18 +104,6 @@ class AssetEditActivity(
         super.onCreate(savedInstanceState)
 
         val toolbar: Toolbar = findViewById(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
-
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.assets_settings)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/AssetsActivity.kt
@@ -65,18 +65,6 @@ class AssetsActivity : ThemedActivity(), UndoSnackbarManager.Interface<File> {
         updating = findViewById(R.id.action_updating)
         updating.isGone = true
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.recyclerView) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -88,6 +76,8 @@ class AssetsActivity : ThemedActivity(), UndoSnackbarManager.Interface<File> {
             )
             insets
         }
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.route_assets)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/GroupFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/GroupFragment.kt
@@ -65,17 +65,6 @@ class GroupFragment : ToolbarFragment(R.layout.layout_group),
         toolbar.setTitle(R.string.menu_group)
         toolbar.inflateMenu(R.menu.add_group_menu)
         toolbar.setOnMenuItemClickListener(this)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
 
         groupListView = view.findViewById(R.id.group_list)
         ViewCompat.setOnApplyWindowInsetsListener(groupListView) { v, insets ->

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/GroupSettingsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/GroupSettingsActivity.kt
@@ -231,18 +231,6 @@ class GroupSettingsActivity(
         super.onCreate(savedInstanceState)
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
-
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.group_settings)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/LogcatFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/LogcatFragment.kt
@@ -43,17 +43,6 @@ class LogcatFragment : ToolbarFragment(R.layout.layout_logcat),
         toolbar.inflateMenu(R.menu.logcat_menu)
         toolbar.setOnMenuItemClickListener(this)
         binding = LayoutLogcatBinding.bind(view)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.logView) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/RouteFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/RouteFragment.kt
@@ -40,17 +40,6 @@ class RouteFragment : ToolbarFragment(R.layout.layout_route), Toolbar.OnMenuItem
         toolbar.setTitle(R.string.menu_route)
         toolbar.inflateMenu(R.menu.add_route_menu)
         toolbar.setOnMenuItemClickListener(this)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
 
         ruleListView = view.findViewById(R.id.route_list)
         ViewCompat.setOnApplyWindowInsetsListener(ruleListView) { v, insets ->

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/RouteSettingsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/RouteSettingsActivity.kt
@@ -414,18 +414,6 @@ class RouteSettingsActivity(
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.toolbar)) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         setSupportActionBar(findViewById(R.id.toolbar))
         supportActionBar?.apply {
             setTitle(R.string.menu_route)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/SettingsFragment.kt
@@ -13,17 +13,6 @@ class SettingsFragment : ToolbarFragment(R.layout.layout_config_settings) {
         super.onViewCreated(view, savedInstanceState)
 
         toolbar.setTitle(R.string.settings)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
 
         if (savedInstanceState == null) parentFragmentManager.beginTransaction()
             .replace(R.id.settings, SettingsPreferenceFragment())

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/ThemedActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/ThemedActivity.kt
@@ -8,8 +8,13 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.snackbar.Snackbar
+import io.nekohasekai.sagernet.R
 import io.nekohasekai.sagernet.utils.Theme
 
 abstract class ThemedActivity : AppCompatActivity {
@@ -56,6 +61,19 @@ abstract class ThemedActivity : AppCompatActivity {
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             WindowCompat.getInsetsController(window, window.decorView).isAppearanceLightNavigationBars = !Theme.usingNightMode()
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            findViewById<AppBarLayout>(R.id.appbar)?.apply {
+                updatePadding(
+                    top = bars.top,
+                    left = bars.left,
+                    right = bars.right,
+                )
+            }
+            insets
         }
     }
 

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/configuration/ConfigurationFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/configuration/ConfigurationFragment.kt
@@ -197,19 +197,6 @@ class ConfigurationFragment @JvmOverloads constructor(
                 requireActivity().finish()
             }
         }
-
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
-
         val activity = activity
         val searchView = toolbar.findViewById<SearchView>(R.id.action_search)
         if (searchView != null) {

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/configuration/ScannerActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/configuration/ScannerActivity.kt
@@ -34,14 +34,10 @@ import androidx.appcompat.widget.Toolbar
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
-import androidx.camera.core.TorchState
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -70,17 +66,6 @@ class ScannerActivity : ThemedActivity() {
         setContentView(binding.root)
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.add_profile_methods_scan_qr_code)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/dashboard/ConnectionFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/dashboard/ConnectionFragment.kt
@@ -56,11 +56,6 @@ class ConnectionFragment() :
                 (requireActivity() as MainActivity).onBackPressedCallback.isEnabled = true
             }
         }
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val statusBarTop = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
-            v.updatePadding(top = statusBarTop)
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/dashboard/DashboardFragment.kt
@@ -54,17 +54,6 @@ class DashboardFragment : ToolbarFragment(R.layout.layout_dashboard),
         toolbar.setTitle(R.string.menu_dashboard)
         toolbar.inflateMenu(R.menu.dashboard_menu)
         toolbar.setOnMenuItemClickListener(this)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.dashboardTab) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/profile/ConfigEditActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/profile/ConfigEditActivity.kt
@@ -77,18 +77,6 @@ class ConfigEditActivity : ThemedActivity() {
         binding = LayoutEditConfigBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.editor) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -110,6 +98,7 @@ class ConfigEditActivity : ThemedActivity() {
             insets
         }
 
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.config_settings)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/profile/ProfileSettingsActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/profile/ProfileSettingsActivity.kt
@@ -123,17 +123,6 @@ abstract class ProfileSettingsActivity<T : AbstractBean>(
         super.onCreate(savedInstanceState)
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.profile_config)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/tools/GetCertActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/tools/GetCertActivity.kt
@@ -32,18 +32,6 @@ class GetCertActivity : ThemedActivity() {
         binding = LayoutGetCertBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.mainLayout) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -56,6 +44,7 @@ class GetCertActivity : ThemedActivity() {
             insets
         }
 
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.get_cert)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/tools/RuleSetMatchActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/tools/RuleSetMatchActivity.kt
@@ -37,18 +37,6 @@ class RuleSetMatchActivity : ThemedActivity() {
         binding = LayoutRuleSetMatchBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.mainLayout) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -61,6 +49,7 @@ class RuleSetMatchActivity : ThemedActivity() {
             insets
         }
 
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.rule_set_match)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/tools/SpeedtestActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/tools/SpeedtestActivity.kt
@@ -30,18 +30,6 @@ class SpeedtestActivity : ThemedActivity() {
         binding = LayoutSpeedTestBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.mainLayout) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -54,7 +42,8 @@ class SpeedtestActivity : ThemedActivity() {
             insets
         }
 
-        setSupportActionBar(findViewById(R.id.toolbar))
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.speed_test)
             setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/tools/StunActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/tools/StunActivity.kt
@@ -28,18 +28,6 @@ class StunActivity : ThemedActivity() {
         binding = LayoutStunBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.mainLayout) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -52,6 +40,7 @@ class StunActivity : ThemedActivity() {
             insets
         }
 
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             title = getString(R.string.stun_test)

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/tools/ToolsFragment.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/tools/ToolsFragment.kt
@@ -28,17 +28,6 @@ class ToolsFragment : ToolbarFragment(R.layout.layout_tools) {
         val binding = LayoutToolsBinding.bind(view)
         binding.toolsPager.adapter = ToolsAdapter(tools)
 
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.toolsTab) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

--- a/app/src/main/java/io/nekohasekai/sagernet/ui/tools/VPNScannerActivity.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ui/tools/VPNScannerActivity.kt
@@ -41,18 +41,6 @@ class VPNScannerActivity : ThemedActivity() {
         this.binding = binding
         setContentView(binding.root)
 
-        toolbar = findViewById(R.id.toolbar)
-        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, insets ->
-            val bars = insets.getInsets(
-                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
-            )
-            v.updatePadding(
-                top = bars.top,
-                left = bars.left,
-                right = bars.right,
-            )
-            insets
-        }
         ViewCompat.setOnApplyWindowInsetsListener(binding.scanVPNResult) { v, insets ->
             val bars = insets.getInsets(
                 WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
@@ -64,6 +52,8 @@ class VPNScannerActivity : ThemedActivity() {
             )
             insets
         }
+
+        toolbar = findViewById(R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setTitle(R.string.scan_vpn_app)

--- a/app/src/main/res/layout/layout_appbar.xml
+++ b/app/src/main/res/layout/layout_appbar.xml
@@ -2,6 +2,7 @@
 <com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/appbar"
+    android:background="?attr/colorPrimary"
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
     android:elevation="4dp">

--- a/app/src/main/res/layout/layout_logcat.xml
+++ b/app/src/main/res/layout/layout_logcat.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".ui.tools.ToolsFragment">
 
     <include
@@ -29,4 +30,4 @@
         app:layoutManager="io.nekohasekai.sagernet.widget.FixedLinearLayout"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/layout_rule_set_match.xml
+++ b/app/src/main/res/layout/layout_rule_set_match.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -88,4 +87,4 @@
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>


### PR DESCRIPTION
Fix title of `MaterialToolbar` not aligned with menu item icons (after MD3 refactoring).

`AppBarLayout` should be padded instead of `MaterialToolbar`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed dynamic padding adjustments for toolbars in multiple screens, which may affect how toolbars align with system bars and display cutouts.
  * Updated app bar layout to consistently use the primary theme color as its background.
  * Changed some layout containers from CoordinatorLayout to LinearLayout for improved consistency and layout behavior.

* **Bug Fixes**
  * Ensured app bar and toolbar backgrounds are visually consistent across the app.

These changes may result in subtle differences in toolbar spacing and appearance, especially on devices with display cutouts or system bars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->