### PR TITLE
Correct $version_code placeholder replacement order

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/ktx/Nets.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/ktx/Nets.kt
@@ -113,8 +113,8 @@ Replace all version-about escapes in userAent
  */
 fun generateUserAgent(userAgent: String): String {
     if (userAgent.isBlank()) return USER_AGENT
-    return userAgent.replace("\$version", BuildConfig.VERSION_NAME)
-        .replace("\$version_code", BuildConfig.VERSION_CODE.toString())
+    return userAgent.replace("\$version_code", BuildConfig.VERSION_CODE.toString())
+        .replace("\$version", BuildConfig.VERSION_NAME)
         .replace("\$box_version", Libcore.versionBox())
 }
 


### PR DESCRIPTION
## Summary
- remove the fallback PackageManager lookup and keep the original lightweight BuildConfig-only logic
- ensure `$version_code` is substituted before `$version` so the shorter token no longer corrupts the longer placeholder

## Testing
- not run (not requested)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected user agent generation so version and build number are reliably substituted, improving identification consistency across network requests.
  - Enhances compatibility with services relying on accurate user agent data and ensures more reliable analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->