### PR TITLE
fix(log):sendlog-logfile-ouput2str-UTF-8

### DIFF
--- a/app/src/main/java/io/nekohasekai/sagernet/utils/SendLog.kt
+++ b/app/src/main/java/io/nekohasekai/sagernet/utils/SendLog.kt
@@ -21,7 +21,7 @@ object SendLog {
         val content = buildString {
             appendLine(CrashHandler.buildReportHeader())
             appendLine("Logcat: \n")
-            appendLine(getCoreLog(externalAssetsDir, 0))
+            appendLine(getCoreLog(externalAssetsDir, 0).toString(Charsets.UTF_8))
         }
 
         try {
@@ -41,7 +41,7 @@ object SendLog {
         append(CrashHandler.buildReportHeader())
         appendLine("Logcat: ")
         appendLine()
-        appendLine(getCoreLog(externalAssetsDir, 0))
+        appendLine(getCoreLog(externalAssetsDir, 0).toString(Charsets.UTF_8))
     }
 
     private fun getCoreLog(externalAssetsDir: File, max: Long): ByteArray {


### PR DESCRIPTION
The exported log showed output like “[B@xxxxxx” instead of the actual log content because a ByteArray was appended directly to the String builder. 

This change converts the ByteArray to a UTF-8 String before appending, so the log is correctly included in the exported log.

Please review this change. Thank you for maintaining this project. )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where log data was not properly decoded, ensuring logs display correctly as readable text in diagnostic reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->