### PR TITLE
Fix running `tasks` gradle task on Windows

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -26,10 +26,10 @@ val supportedDesktopTargets =
 
 fun normalizeDesktopPlatform(rawValue: String): String {
     val value = rawValue.trim().lowercase()
-    return when (value) {
-        "linux" -> "linux"
-        "darwin", "macos", "mac", "osx" -> "darwin"
-        "windows", "win" -> "windows"
+    return when {
+        value.contains("linux") -> "linux"
+        value.contains("darwin") || value.contains("mac") || value.contains("osx") -> "darwin"
+        value.contains("windows") || value.contains("win") -> "windows"
         else -> error("Unsupported desktop platform '$rawValue'. Use linux, darwin, or windows.")
     }
 }


### PR DESCRIPTION
A simple fix to be able to actually run gradle tasks on windows.
Fixes error: `Unsupported desktop platform 'Windows 11'. Use linux, darwin, or windows.`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced desktop platform recognition to support a broader range of platform name inputs, improving compatibility across different naming conventions for Linux, macOS, and Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->