### PR TITLE
fix: include DNS evaluate action fields in generated DNSRuleAction class

### DIFF
--- a/libcore/cmd/boxoption/build.go
+++ b/libcore/cmd/boxoption/build.go
@@ -328,6 +328,10 @@ func init() {
 			Value: option.DNSRouteOptionsActionOptions{},
 		},
 		{
+			Key:   "EvaluateOptions",
+			Value: option.DNSEvaluateActionOptions{},
+		},
+		{
 			Key:   "Predefined",
 			Value: option.DNSRouteActionPredefined{},
 		},


### PR DESCRIPTION
## Summary
- `TestDNSRuleActionFields` in `libcore/cmd/boxoption/build_test.go` was failing because the generated `DNSRuleAction` Kotlin class was missing the `tag` field (and others from `DNSEvaluateActionOptions`).
- `dnsRuleActions` in `libcore/cmd/boxoption/build.go` omitted `option.DNSEvaluateActionOptions{}`, so its fields were never emitted by the generator.
- Added the missing `EvaluateOptions` entry to `dnsRuleActions`.

## Test plan
- [x] `cd libcore && go test -count=1 ./...` passes (previously `TestDNSRuleActionFields` failed)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VD3PmRvSqRdiWtKa4gq4Wv)_