### PR TITLE
feat: decode QR code when importing an image from clipboard

### DIFF
--- a/composeApp/src/androidMain/kotlin/fr/husi/compose/ClipboardPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/fr/husi/compose/ClipboardPlatform.android.kt
@@ -1,10 +1,13 @@
 package fr.husi.compose
 
 import android.content.ClipData
+import android.graphics.BitmapFactory
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.toClipEntry
 import androidx.core.content.FileProvider
+import fr.husi.ktx.Logs
 import fr.husi.ktx.onIoDispatcher
 import fr.husi.repository.resolveAndroidRepository
 import fr.husi.repository.resolveRepository
@@ -20,6 +23,28 @@ actual suspend fun Clipboard.setPlainText(text: String) {
 
 actual suspend fun Clipboard.getPlainText(): String? {
     return getClipEntry()?.clipData?.takeIf { it.itemCount > 0 }?.getItemAt(0)?.text?.toString()
+}
+
+actual suspend fun Clipboard.getFirstContent(): ClipboardContent? {
+    val item = getClipEntry()?.clipData?.takeIf { it.itemCount > 0 }?.getItemAt(0) ?: return null
+    item.text?.toString()?.let { return ClipboardContent.Text(it) }
+
+    val context = resolveAndroidRepository().context
+    val uri = item.uri ?: return null
+    return onIoDispatcher {
+        try {
+            if (context.contentResolver.getType(uri)?.startsWith("image/") == true) {
+                context.contentResolver.openInputStream(uri)
+                    .use { BitmapFactory.decodeStream(it) }
+                    ?.let { ClipboardContent.Image(it.asImageBitmap()) }
+            } else {
+                item.coerceToText(context)?.toString()?.let(ClipboardContent::Text)
+            }
+        } catch (e: Exception) {
+            Logs.e(e)
+            null
+        }
+    }
 }
 
 actual suspend fun Clipboard.setImage(bitmap: ImageBitmap) {

--- a/composeApp/src/commonMain/kotlin/fr/husi/compose/ClipboardPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/compose/ClipboardPlatform.kt
@@ -3,8 +3,21 @@ package fr.husi.compose
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.Clipboard
 
+/** The first entry of the clipboard, if it is something we can import from. */
+sealed interface ClipboardContent {
+    data class Text(val text: String) : ClipboardContent
+
+    data class Image(val bitmap: ImageBitmap) : ClipboardContent
+}
+
 expect suspend fun Clipboard.setPlainText(text: String)
 
 expect suspend fun Clipboard.getPlainText(): String?
+
+/**
+ * Reads the first item of the clipboard. Plain text is returned as is, an image is returned so
+ * that the caller can try to decode a QR code from it.
+ */
+expect suspend fun Clipboard.getFirstContent(): ClipboardContent?
 
 expect suspend fun Clipboard.setImage(bitmap: ImageBitmap)

--- a/composeApp/src/commonMain/kotlin/fr/husi/compose/QRCodeDecoder.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/compose/QRCodeDecoder.kt
@@ -1,0 +1,48 @@
+package fr.husi.compose
+
+import androidx.compose.ui.graphics.ImageBitmap
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.common.GlobalHistogramBinarizer
+import com.google.zxing.common.HybridBinarizer
+import fr.husi.ktx.Logs
+
+private val decodeHints = mapOf(
+    DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE),
+    DecodeHintType.TRY_HARDER to true,
+)
+
+/** Decodes the QR code contained in [bitmap], or null if there is none. */
+fun decodeQRCode(bitmap: ImageBitmap): String? {
+    val width = bitmap.width
+    val height = bitmap.height
+    if (width <= 0 || height <= 0) return null
+
+    val source = try {
+        val pixels = IntArray(width * height)
+        bitmap.readPixels(pixels)
+        RGBLuminanceSource(width, height, pixels)
+    } catch (e: Exception) {
+        Logs.e(e)
+        return null
+    }
+
+    // HybridBinarizer suits photos, GlobalHistogramBinarizer suits clean screenshots.
+    val binarizers = listOf(
+        BinaryBitmap(HybridBinarizer(source)),
+        BinaryBitmap(GlobalHistogramBinarizer(source)),
+    )
+    for (binaryBitmap in binarizers) {
+        val result = try {
+            MultiFormatReader().decode(binaryBitmap, decodeHints)
+        } catch (_: Exception) {
+            // Not found in this binarization, try the next one.
+            continue
+        }
+        return result.text
+    }
+    return null
+}

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/configuration/ConfigurationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/configuration/ConfigurationScreen.kt
@@ -80,6 +80,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import fr.husi.bg.BackendState
 import fr.husi.bg.ServiceState
 import fr.husi.compose.CapsuleActionButton
+import fr.husi.compose.ClipboardContent
 import fr.husi.compose.CapsuleSearchInputField
 import fr.husi.compose.CapsuleSearchTopBar
 import fr.husi.compose.ExpandableDropdownMenuItem
@@ -91,7 +92,8 @@ import fr.husi.compose.SimpleIconButton
 import fr.husi.compose.StatsBar
 import fr.husi.compose.TextButton
 import fr.husi.compose.colorForUrlTestDelay
-import fr.husi.compose.getPlainText
+import fr.husi.compose.decodeQRCode
+import fr.husi.compose.getFirstContent
 import fr.husi.compose.material3.Icon
 import fr.husi.compose.material3.PrimaryScrollableTabRow
 import fr.husi.compose.material3.Tab
@@ -101,6 +103,7 @@ import fr.husi.database.DataStore
 import fr.husi.database.ProxyEntity
 import fr.husi.database.displayType
 import fr.husi.keyevent.isTypeControlPressed
+import fr.husi.ktx.onIoDispatcher
 import fr.husi.ktx.runOnIoDispatcher
 import fr.husi.ktx.showAndDismissOld
 import fr.husi.repository.resolveRepository
@@ -158,6 +161,7 @@ import fr.husi.resources.menu
 import fr.husi.resources.more
 import fr.husi.resources.more_vert
 import fr.husi.resources.need_reload
+import fr.husi.resources.no_proxies_found_in_clipboard
 import fr.husi.resources.no_proxies_found_in_file
 import fr.husi.resources.note_add
 import fr.husi.resources.ok
@@ -174,6 +178,7 @@ import fr.husi.ui.MainViewModel
 import fr.husi.ui.MainViewModelAlertDialog
 import fr.husi.ui.MainViewModelUiEvent
 import fr.husi.ui.NavRoutes
+import fr.husi.ui.StringOrRes
 import fr.husi.ui.getStringOrRes
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlinx.coroutines.launch
@@ -372,8 +377,22 @@ fun ConfigurationScreen(
 
     fun importFromClipboard() {
         lifecycleOwner.lifecycleScope.launch {
-            val text = clipboard.getPlainText()
-            mainViewModel.parseProxy(text)
+            when (val content = clipboard.getFirstContent()) {
+                is ClipboardContent.Text -> mainViewModel.parseProxy(content.text)
+
+                is ClipboardContent.Image -> {
+                    val text = onIoDispatcher { decodeQRCode(content.bitmap) }
+                    if (text == null) {
+                        mainViewModel.showSnackbar(
+                            StringOrRes.Res(Res.string.no_proxies_found_in_clipboard),
+                        )
+                    } else {
+                        mainViewModel.parseProxy(text)
+                    }
+                }
+
+                null -> mainViewModel.parseProxy(null)
+            }
         }
     }
 

--- a/composeApp/src/desktopMain/kotlin/fr/husi/compose/ClipboardPlatform.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/fr/husi/compose/ClipboardPlatform.desktop.kt
@@ -2,13 +2,20 @@ package fr.husi.compose
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.asAwtTransferable
+import fr.husi.ktx.Logs
+import fr.husi.ktx.onIoDispatcher
+import java.awt.Image
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
 import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import org.jetbrains.skia.Image as SkiaImage
 
 @OptIn(ExperimentalComposeUiApi::class)
 actual suspend fun Clipboard.setPlainText(text: String) {
@@ -22,6 +29,62 @@ actual suspend fun Clipboard.getPlainText(): String? {
             ?.takeIf { it.isDataFlavorSupported(DataFlavor.stringFlavor) }
             ?.getTransferData(DataFlavor.stringFlavor) as? String
     }.getOrNull()
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual suspend fun Clipboard.getFirstContent(): ClipboardContent? {
+    val transferable = try {
+        getClipEntry()?.asAwtTransferable
+    } catch (e: Exception) {
+        Logs.e(e)
+        null
+    } ?: return null
+
+    // Flavors are ordered by the provider's preference, so the first supported one is
+    // the "first item" of the clipboard.
+    for (flavor in transferable.transferDataFlavors) {
+        val data = try {
+            when (flavor) {
+                DataFlavor.stringFlavor, DataFlavor.imageFlavor -> transferable.getTransferData(flavor)
+                else -> continue
+            }
+        } catch (e: Exception) {
+            Logs.e(e)
+            continue
+        }
+        when (data) {
+            is String -> return ClipboardContent.Text(data)
+            is Image -> return data.toImageBitmap()?.let(ClipboardContent::Image)
+            else -> continue
+        }
+    }
+    return null
+}
+
+private fun Image.toBufferedImage(): BufferedImage? {
+    if (this is BufferedImage) return this
+    val width = getWidth(null)
+    val height = getHeight(null)
+    if (width <= 0 || height <= 0) return null
+    return BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB).also {
+        val graphics = it.createGraphics()
+        graphics.drawImage(this, 0, 0, null)
+        graphics.dispose()
+    }
+}
+
+private suspend fun Image.toImageBitmap(): ImageBitmap? = onIoDispatcher {
+    try {
+        val buffered = toBufferedImage() ?: return@onIoDispatcher null
+        SkiaImage.makeFromEncoded(
+            ByteArrayOutputStream().also {
+                ImageIO.write(buffered, "png", it)
+            }.toByteArray(),
+        ).toComposeImageBitmap()
+    } catch (e: Exception) {
+        Logs.e(e)
+        null
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)


### PR DESCRIPTION
Clipboard import on the main screen now looks at the first clipboard item instead of only plain text:

- text → parsed as before;
- image → decoded as a QR code, and the decoded content is fed into the usual import path;
- if the image contains no QR code, a "No proxies found in the clipboard" snackbar is shown.

Implemented on both Android and desktop.

## Changes

- `ClipboardPlatform.kt`: new `ClipboardContent` (`Text`/`Image`) and `expect Clipboard.getFirstContent()`. `getPlainText()` is kept as is.
- `ClipboardPlatform.android.kt`: reads item 0 — text first, otherwise a `content://` URI whose MIME type is `image/*` is decoded into a bitmap on the IO dispatcher; other URIs fall back to `coerceToText`.
- `ClipboardPlatform.desktop.kt`: walks the transferable's flavors in provider order, taking `stringFlavor` or `imageFlavor`; the AWT image is converted to an `ImageBitmap` through PNG encoding (same route the existing desktop QR code uses).
- `QRCodeDecoder.kt` (new, commonMain): zxing-based `decodeQRCode(ImageBitmap)` with `TRY_HARDER`, trying `HybridBinarizer` then `GlobalHistogramBinarizer`.
- `ConfigurationScreen.kt`: `importFromClipboard()` dispatches on the clipboard content type.

## Testing

Not built in this environment — no Gradle cache / Android SDK / libcore artifacts are available here, so `make test_gradle` could not run. Worth a manual check of copy-image-then-import on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBk1o43UBaTNaCLEdPVeXn

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBk1o43UBaTNaCLEdPVeXn)_