### PR TITLE
Add NO_NAIVE build option to skip cronet-go dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ auto-detected; for Darwin targets on non-Darwin hosts also pass `DARWIN_SDK=/pat
 uses `zig cc`). Linux desktop builds pull in `cronet-go` for naive outbound — set `CRONET_GO_ROOT`
 if it's not in `../../cronet-go` or `$HOME/cronet-go`.
 
+In restricted environments without a `cronet-go` checkout (or without network access to fetch
+one), pass `NO_NAIVE=1` to `make libcore` / `make libcore_desktop` (or `--no-naive` to
+`libcore/build.sh` directly) to drop the `with_naive_outbound` build tag and skip the cronet-go
+toolchain setup entirely. The resulting build omits the naive outbound protocol.
+
 Desktop Gradle picks the libcore jar from `os.name`/`os.arch`; override with
 `./gradlew -p composeApp run -PdesktopTarget=linux/amd64`. Missing jars fail the build immediately
 rather than silently falling back.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ DESKTOP_TARGET_GRADLE_ARG = $(if $(DESKTOP_TARGET),-PdesktopTarget=$(DESKTOP_TAR
 DESKTOP_TARGET_SCRIPT_ARG = $(if $(DESKTOP_TARGET),--target $(DESKTOP_TARGET),)
 JNI_INCLUDE_SCRIPT_ARG = $(if $(JNI_INCLUDE),--jniinclude "$(JNI_INCLUDE)",)
 DARWIN_SDK_SCRIPT_ARG = $(if $(DARWIN_SDK),--darwinsdk "$(DARWIN_SDK)",)
+NO_NAIVE_SCRIPT_ARG = $(if $(filter 1,$(NO_NAIVE)),--no-naive,)
 LAUNCHER_ZIG_TARGET = $(subst linux/amd64,x86_64-linux-musl,$(subst linux/arm64,aarch64-linux-musl,$(subst darwin/amd64,x86_64-macos,$(subst darwin/arm64,aarch64-macos,$(subst windows/amd64,x86_64-windows,$(subst windows/arm64,aarch64-windows,$(DESKTOP_TARGET)))))))
 LAUNCHER_ZIG_TARGET_ARG = $(if $(LAUNCHER_ZIG_TARGET),-Dtarget=$(LAUNCHER_ZIG_TARGET),)
 
@@ -21,7 +22,7 @@ LAUNCHER_ZIG_TARGET_ARG = $(if $(LAUNCHER_ZIG_TARGET),-Dtarget=$(LAUNCHER_ZIG_TA
 build: libcore_android assets apk
 
 libcore:
-	./run lib core --desktop $(JNI_INCLUDE_SCRIPT_ARG) $(DARWIN_SDK_SCRIPT_ARG)
+	./run lib core --desktop $(JNI_INCLUDE_SCRIPT_ARG) $(DARWIN_SDK_SCRIPT_ARG) $(NO_NAIVE_SCRIPT_ARG)
 
 libcore_android:
 	./run lib core --android
@@ -34,7 +35,7 @@ libcore_desktop:
 		echo "DESKTOP_TARGETS is required, e.g. make libcore_desktop DESKTOP_TARGETS=linux/amd64,darwin/arm64"; \
 		exit 1; \
 	fi
-	./run lib core --desktop --desktoptargets $(DESKTOP_TARGETS) $(JNI_INCLUDE_SCRIPT_ARG) $(DARWIN_SDK_SCRIPT_ARG)
+	./run lib core --desktop --desktoptargets $(DESKTOP_TARGETS) $(JNI_INCLUDE_SCRIPT_ARG) $(DARWIN_SDK_SCRIPT_ARG) $(NO_NAIVE_SCRIPT_ARG)
 
 desktop:
 	BUILD_PLUGIN=none ./gradlew -p composeApp run

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ For Darwin targets on non-Darwin hosts, `libcore/build.sh` uses `zig cc` / `zig 
 path via `DARWIN_SDK` or `--darwinsdk`, exports the matching `CGO_*` sysroot/library flags, keeps
 `with_naive_outbound`, and does not require a `cronet-go` checkout, so `zig` must be available in `PATH`.
 
+If `cronet-go` isn't available and you don't need the naive outbound protocol (e.g. in a restricted build
+environment), pass `NO_NAIVE=1` (or `--no-naive` to `libcore/build.sh` directly) to drop `with_naive_outbound`
+from the build tags and skip the cronet-go toolchain setup entirely:
+
+```shell
+NO_NAIVE=1 make libcore_desktop DESKTOP_TARGETS=linux/amd64
+```
+
 Desktop Gradle builds select `composeApp/libs/libcore-desktop-<platform>-<arch>.jar` automatically from the current
 `os.name` and `os.arch`.
 

--- a/libcore/build.sh
+++ b/libcore/build.sh
@@ -18,6 +18,7 @@ IFS="," BUILD_TAGS="${TAGS[*]}"
 BUILD_DESKTOP=0
 BUILD_ANDROID=0
 PLATFORM_SPECIFIED=0
+NO_NAIVE="${NO_NAIVE:-0}"
 DESKTOP_TARGETS=""
 DESKTOP_OUTPUTS=()
 JNI_INCLUDE=""
@@ -373,6 +374,10 @@ while [ "$#" -gt 0 ]; do
         DARWIN_SDKROOT="${1#*=}"
         shift
         ;;
+    --no-naive)
+        NO_NAIVE=1
+        shift
+        ;;
     *)
         echo "Unknown argument: $1"
         exit 1
@@ -382,6 +387,10 @@ done
 
 if [ "$PLATFORM_SPECIFIED" == "0" ]; then
     BUILD_ANDROID=1
+fi
+
+if [ "$NO_NAIVE" == "1" ]; then
+    BUILD_TAGS="$(remove_build_tag "$BUILD_TAGS" "with_naive_outbound")"
 fi
 
 # Just install anja & anjb if not have or version not same


### PR DESCRIPTION
## Summary

- Add a `--no-naive` flag to `libcore/build.sh` (and a `NO_NAIVE=1` env/make var passed through `make libcore` / `make libcore_desktop`) that drops the `with_naive_outbound` build tag, so the naive outbound protocol is excluded and the `cronet-go` toolchain setup is skipped entirely.
- Document the option in `AGENTS.md` (symlinked as `CLAUDE.md`) and `README.md` for use in restricted environments that lack a `cronet-go` checkout or network access to fetch one.

## Details

`libcore/build.sh` already required `cronet-go` (or `zig` on Darwin cross-builds) whenever the `with_naive_outbound` tag was present. This adds an opt-out: with `NO_NAIVE=1`, the tag is removed from `BUILD_TAGS` before the desktop/android build runs, so `apply_naive_toolchain_env` (and its `cronet-go` resolution) is never invoked. The Go side already has a stub (`libcore/distro/outbound_naive_stub.go`) for builds without the tag, so no Go changes were needed.

## Test plan

- [x] `bash -n libcore/build.sh` — syntax check
- [x] `go build -tags="with_gvisor,with_quic,with_wireguard,with_openconnect,with_openvpn,with_utls" ./distro/...` (i.e. without `with_naive_outbound`) — compiles cleanly using the existing stub
- [ ] `NO_NAIVE=1 make libcore_desktop DESKTOP_TARGETS=linux/amd64` on a machine without `cronet-go` (not run in this sandbox — full anja/gomobile toolchain unavailable)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SxFNdywGKNrAFX6jaZK2gk)_