### PR TITLE
chore(renovate): add gradle groups for previously ungrouped deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -111,7 +111,8 @@
         "androidx.activity{/,}**",
         "androidx.browser{/,}**",
         "androidx.lifecycle{/,}**",
-        "androidx.camera{/,}**"
+        "androidx.camera{/,}**",
+        "androidx.tv{/,}**"
       ]
     },
     {
@@ -141,7 +142,8 @@
       "matchPackageNames": [
         "com.esotericsoftware:kryo",
         "com.jakewharton:process-phoenix",
-        "org.ini4j:ini4j"
+        "org.ini4j:ini4j",
+        "com.github.ajalt.clikt{/,}**"
       ],
       "groupName": "Utility Libraries",
       "groupSlug": "utility-libraries"
@@ -164,7 +166,30 @@
       "groupName": "Testing",
       "groupSlug": "testing",
       "matchPackageNames": [
-        "org.junit{/,}**"
+        "org.junit{/,}**",
+        "io.mockk{/,}**"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "Koin",
+      "groupSlug": "koin",
+      "matchPackageNames": [
+        "io.insert-koin{/,}**"
+      ]
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "groupName": "Desktop Native Integration",
+      "groupSlug": "desktop-native-integration",
+      "matchPackageNames": [
+        "io.github.kdroidfilter{/,}**",
+        "com.github.hypfvieh{/,}**",
+        "net.java.dev.jna{/,}**"
       ]
     },
     {


### PR DESCRIPTION
## Summary

跟进 #822：核对了 `gradle/libs.versions.toml` 中的所有依赖，发现以下几组虽然被 renovate 追踪，但没有落在任何 `groupName` 里，会各自单独开 PR：

- `clikt`（`com.github.ajalt.clikt`）→ 并入 **Utility Libraries**
- `mockk`（`io.mockk`）→ 并入 **Testing**
- `koin-*` 系列（`io.insert-koin`，bom/core/android/compose 等多个模块）→ 新建 **Koin** 组
- `com-kdroid-composetray`（`io.github.kdroidfilter`）、`dbus-java-*`（`com.github.hypfvieh`）、`jna-platform`（`net.java.dev.jna`）→ 新建 **Desktop Native Integration** 组
- `androidx-tv-material`（`androidx.tv`）→ 并入 **AndroidX Core & UI**

不改变其他分组逻辑，只是把散落的依赖归到语义相近的组里，减少 renovate 单独开的 PR 数量。

## Test plan

- [x] `python3 -c "import json; json.load(open('.github/renovate.json'))"` 校验 JSON 合法

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXcpiHQD3xyFA7uP9ytwbh)_