### PR TITLE
chore(renovate): block Compose snapshot builds and datetime compat versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -214,6 +214,24 @@
         "com.google.guava:guava"
       ],
       "allowedVersions": "/-android$/"
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "org.jetbrains.compose**"
+      ],
+      "allowedVersions": "!/(-[Ss][Nn][Aa][Pp][Ss][Hh][Oo][Tt](\\+.*)?|\\+dev\\d+)$/"
+    },
+    {
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "org.jetbrains.kotlinx:kotlinx-datetime"
+      ],
+      "allowedVersions": "!/(-[Ss][Nn][Aa][Pp][Ss][Hh][Oo][Tt](\\+.*)?|-compat)$/"
     }
   ]
 }


### PR DESCRIPTION
## Summary

针对 #820 和 #824 这两个不该出现的 renovate PR 补规则：

- **#820**：`org.jetbrains.compose.material3:material3` 被建议升到 `1.11.0-alpha08+dev4064`。现有的全局 `allowedVersions` 只过滤了 Maven 标准的 `-SNAPSHOT` 后缀，没覆盖 JetBrains 自家的 `+devNNNN` 快照版本号格式。新增一条只针对 `org.jetbrains.compose**`（涵盖 `org.jetbrains.compose:*` 与 `org.jetbrains.compose.material3:*`）的规则，同时排除 `-SNAPSHOT` 和 `+devNNNN` 两种快照格式。
- **#824**：`org.jetbrains.kotlinx:kotlinx-datetime` 被建议升到 `0.8.0-0.6.x-compat`，这是官方为兼容旧 0.6.x API 发布的独立版本线，不是我们想要的升级路径。新增一条针对该包的规则，排除 `-compat` 后缀（同样保留原有 `-SNAPSHOT` 过滤）。

两条新规则放在原有的全局 catch-all 规则之后，因为 Renovate 对同一 `allowedVersions` 字段是后者覆盖前者，需要在新规则里把原有的 SNAPSHOT 过滤条件也带上，否则会丢失。

## Test plan

- [x] `python3 -c "import json; json.load(open('.github/renovate.json'))"` 校验 JSON 合法
- [ ] 关闭 #820 / #824，观察下次 renovate 扫描不再重新提出这两个更新

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXcpiHQD3xyFA7uP9ytwbh)_