### PR TITLE
Add close button to expanded search bar in app list

### DIFF
--- a/composeApp/src/androidMain/kotlin/fr/husi/ui/AbstractAppList.kt
+++ b/composeApp/src/androidMain/kotlin/fr/husi/ui/AbstractAppList.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.SearchBarValue
 import androidx.compose.material3.SnackbarDuration
 import fr.husi.compose.SwipeableSnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -81,6 +82,7 @@ import fr.husi.resources.action_copy
 import fr.husi.resources.action_import
 import fr.husi.resources.action_import_err
 import fr.husi.resources.action_import_msg
+import fr.husi.resources.cancel
 import fr.husi.resources.close
 import fr.husi.resources.content_paste
 import fr.husi.resources.copy_all
@@ -373,6 +375,20 @@ internal fun AppListScaffold(
             },
             leadingIcon = {
                 Icon(vectorResource(Res.drawable.search), null)
+            },
+            trailingIcon = if (searchBarState.currentValue == SearchBarValue.Expanded) {
+                {
+                    SimpleIconButton(
+                        imageVector = vectorResource(Res.drawable.close),
+                        contentDescription = stringResource(Res.string.cancel),
+                        onClick = {
+                            textFieldState.setTextAndPlaceCursorAtEnd("")
+                            scope.launch { searchBarState.animateToCollapsed() }
+                        },
+                    )
+                }
+            } else {
+                null
             },
         )
     }


### PR DESCRIPTION
## Summary
- Add a trailing close icon to the app list's search input field, shown only while the search bar is expanded
- Tapping it clears the query and collapses the search bar back, matching the existing pattern in `ConfigurationScreen.kt` / `LogcatScreen.kt`

## Test plan
- [ ] Open app list (per-app proxy) screen, expand search, verify close button appears and clears/collapses on tap
- No Android SDK available in this sandbox, so this could not be compiled/run here

---
_Generated by [Claude Code](https://claude.ai/code/session_011anrBWmVEj489E6LNfyPBg)_