### PR TITLE
feat(dashboard): lay out the proxies of a set in a Grid

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastCoerceAtLeast
 import fr.husi.compose.BoxedVerticalScrollbar
 import fr.husi.compose.SimpleIconButton
 import fr.husi.compose.colorForUrlTestDelay
@@ -285,15 +286,8 @@ private fun ProxySetCard(
 private const val PROXY_COLUMNS = 2
 
 /** Gap between the proxy cards of a set. */
-private val PROXY_CARD_GAP = 8.dp
+private const val PROXY_CARD_GAP = 8
 
-/**
- * Grid of the proxies of [proxySet].
- *
- * This uses the non lazy [Grid]: the card lives inside a lazy list item, so a lazy grid would be
- * measured with an unbounded height. The proxies of a single set are few enough to lay out eagerly
- * anyway.
- */
 @Composable
 private fun ProxyGrid(
     modifier: Modifier = Modifier,
@@ -303,14 +297,14 @@ private fun ProxyGrid(
 ) {
     Grid(
         config = {
-            gap(PROXY_CARD_GAP)
+            gap(PROXY_CARD_GAP.toDp())
             // A flexible track starts at its min content width, which would make the columns
             // uneven, so split the available width evenly instead. The config block runs during
             // measure, so the constraints are the ones the grid is measured with.
             if (constraints.hasBoundedWidth) {
-                val gaps = PROXY_CARD_GAP.roundToPx() * (PROXY_COLUMNS - 1)
+                val gaps = PROXY_CARD_GAP * (PROXY_COLUMNS - 1)
                 val columnWidth = ((constraints.maxWidth - gaps) / PROXY_COLUMNS)
-                    .coerceAtLeast(0)
+                    .fastCoerceAtLeast(0)
                     .toDp()
                 repeat(PROXY_COLUMNS) { column(columnWidth) }
             } else {

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@file:OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalGridApi::class)
 
 package fr.husi.ui.dashboard
 
@@ -13,6 +13,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalGridApi
+import androidx.compose.foundation.layout.Grid
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -228,32 +230,11 @@ private fun ProxySetCard(
                     }
 
                     if (expanded) {
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            proxySet.items.chunked(2).forEach { rowItems ->
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                ) {
-                                    rowItems.forEach { proxy ->
-                                        val selected = proxySet.selected == proxy.tag
-                                        ProxyCard(
-                                            modifier = Modifier.weight(1f),
-                                            proxy = proxy,
-                                            selected = selected,
-                                            selectable = proxySet.selectable,
-                                            select = { selectProxy(proxySet.tag, proxy.tag) },
-                                            urlTest = { urlTestSingle(proxy.tag) },
-                                        )
-                                    }
-                                    // Fill remaining space if odd number of items
-                                    if (rowItems.size == 1) {
-                                        Spacer(modifier = Modifier.weight(1f))
-                                    }
-                                }
-                            }
-                        }
+                        ProxyGrid(
+                            proxySet = proxySet,
+                            selectProxy = selectProxy,
+                            urlTestSingle = urlTestSingle,
+                        )
                     } else if (!proxySet.isAll) {
                         Surface(
                             color = MaterialTheme.colorScheme.surfaceContainer,
@@ -296,6 +277,56 @@ private fun ProxySetCard(
                     }
                 }
             }
+        }
+    }
+}
+
+/** Number of proxy cards per row. */
+private const val PROXY_COLUMNS = 2
+
+/** Gap between the proxy cards of a set. */
+private val PROXY_CARD_GAP = 8.dp
+
+/**
+ * Grid of the proxies of [proxySet].
+ *
+ * This uses the non lazy [Grid]: the card lives inside a lazy list item, so a lazy grid would be
+ * measured with an unbounded height. The proxies of a single set are few enough to lay out eagerly
+ * anyway.
+ */
+@Composable
+private fun ProxyGrid(
+    modifier: Modifier = Modifier,
+    proxySet: ProxySet,
+    selectProxy: (group: String, tag: String) -> Unit,
+    urlTestSingle: (tag: String) -> Unit,
+) {
+    Grid(
+        config = {
+            gap(PROXY_CARD_GAP)
+            // A flexible track starts at its min content width, which would make the columns
+            // uneven, so split the available width evenly instead. The config block runs during
+            // measure, so the constraints are the ones the grid is measured with.
+            if (constraints.hasBoundedWidth) {
+                val gaps = PROXY_CARD_GAP.roundToPx() * (PROXY_COLUMNS - 1)
+                val columnWidth = ((constraints.maxWidth - gaps) / PROXY_COLUMNS)
+                    .coerceAtLeast(0)
+                    .toDp()
+                repeat(PROXY_COLUMNS) { column(columnWidth) }
+            } else {
+                repeat(PROXY_COLUMNS) { column(1.fr) }
+            }
+        },
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        proxySet.items.forEach { proxy ->
+            ProxyCard(
+                proxy = proxy,
+                selected = proxySet.selected == proxy.tag,
+                selectable = proxySet.selectable,
+                select = { selectProxy(proxySet.tag, proxy.tag) },
+                urlTest = { urlTestSingle(proxy.tag) },
+            )
         }
     }
 }


### PR DESCRIPTION
The proxies of an expanded proxy set were laid out by hand as `chunked(2)` rows plus a `Spacer` to pad the odd last row. Replace that with the non lazy `Grid` from `androidx.compose.foundation.layout` (`@ExperimentalGridApi`, available since Compose 1.11).

## Changes

`ui/dashboard/DashboardProxySet.kt`: extracted the expanded proxy list into a private `ProxyGrid` composable built on `Grid`, still two columns as before.

The columns are explicitly sized rather than flexible: a `1.fr` track is `minmax(min-content, 1fr)`, so it starts at its min content width and a column holding longer proxy tags ends up wider than the other. The `config` block runs during the measure pass and exposes `constraints`, so the grid splits the available width evenly between the two columns (minus the `8.dp` gap) and the cards stay the same width. The last row no longer needs a filler `Spacer`.

A lazy grid is not usable here: the card sits inside a `LazyColumn` item, so a `LazyVerticalGrid` would be measured with an unbounded height. The proxies of a single set are few enough to lay out eagerly.

The outer `LazyColumn` of proxy set cards is unchanged.

## Testing

`./gradlew :composeApp:compileKotlinDesktop` passes (after building `libcore-desktop-linux-amd64.jar` with `NO_NAIVE=1`). Not verified visually at runtime.