### PR TITLE
fix(async): tighten coroutine scopes around the traffic looper and friends

### DIFF
--- a/composeApp/src/androidMain/kotlin/fr/husi/bg/AppChangeReceiver.kt
+++ b/composeApp/src/androidMain/kotlin/fr/husi/bg/AppChangeReceiver.kt
@@ -12,8 +12,14 @@ import fr.husi.utils.PackageCache
 class AppChangeReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         Logs.d("onReceive: ${intent.action}")
+        // Keep the process alive until the scan finishes, which a bare coroutine cannot do.
+        val pendingResult = goAsync()
         runOnIoDispatcher {
-            checkUpdate(intent)
+            try {
+                checkUpdate(intent)
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/fr/husi/bg/proto/ProxyInstance.kt
+++ b/composeApp/src/androidMain/kotlin/fr/husi/bg/proto/ProxyInstance.kt
@@ -7,8 +7,12 @@ import fr.husi.bg.SpeedStats
 import fr.husi.database.DataStore
 import fr.husi.database.ProxyEntity
 import fr.husi.ktx.Logs
-import fr.husi.ktx.runOnDefaultDispatcher
 import fr.husi.repository.resolveRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 class ProxyInstance(profile: ProxyEntity, var service: BaseService.Interface? = null) :
@@ -17,6 +21,9 @@ class ProxyInstance(profile: ProxyEntity, var service: BaseService.Interface? = 
     var displayProfileName = profile.displayNameForService()
 
     var trafficLooper: TrafficLooper? = null
+
+    /** Owns the traffic looper, cancelled in [close] so nothing outlives this instance. */
+    private val looperScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     override fun buildConfig() {
         super.buildConfig()
@@ -34,12 +41,12 @@ class ProxyInstance(profile: ProxyEntity, var service: BaseService.Interface? = 
 
     override fun launch() {
         super.launch() // start box
-        runOnDefaultDispatcher {
-            val data = service?.data ?: return@runOnDefaultDispatcher
+        looperScope.launch {
+            val data = service?.data ?: return@launch
             trafficLooper = TrafficLooper(
                 box = resolveRepository().boxService!!,
                 config = config,
-                scope = this,
+                scope = looperScope,
                 onSpeedUpdate = { stats ->
                     val speed = stats.toSpeedDisplayData()
                     data.binder.notifySpeed(speed)
@@ -58,6 +65,7 @@ class ProxyInstance(profile: ProxyEntity, var service: BaseService.Interface? = 
             trafficLooper?.stop()
             trafficLooper = null
         }
+        looperScope.cancel()
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/fr/husi/database/preference/PublicDatabase.kt
+++ b/composeApp/src/androidMain/kotlin/fr/husi/database/preference/PublicDatabase.kt
@@ -4,8 +4,9 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import fr.husi.Key
-import fr.husi.ktx.runOnDefaultDispatcher
 import fr.husi.repository.resolveAndroidRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 
 @Database(entities = [KeyValuePair::class], version = 1)
 abstract class PublicDatabase : RoomDatabase() {
@@ -40,7 +41,9 @@ abstract class PublicDatabase : RoomDatabase() {
                 .enableMultiInstanceInvalidation()
                 .fallbackToDestructiveMigration(true)
                 .fallbackToDestructiveMigrationOnDowngrade(true)
-                .setQueryExecutor { runOnDefaultDispatcher { it.run() } }
+                // Room queries block, so they belong on the IO pool rather than the
+                // core-count limited default one.
+                .setQueryExecutor(Dispatchers.IO.asExecutor())
                 .build()
         }
     }

--- a/composeApp/src/commonMain/kotlin/fr/husi/bg/proto/TrafficLooper.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/bg/proto/TrafficLooper.kt
@@ -76,15 +76,17 @@ class TrafficLooper(
     }
 
     private suspend fun loop() = coroutineScope {
+        // Share into this scope rather than the outer one, so that cancelling [job]
+        // in [stop] also tears down these eager collectors.
         val speedInterval = DataStore.configurationStore
             .intFlow(Key.SPEED_INTERVAL, 1000)
-            .stateIn(scope, SharingStarted.Eagerly, 1000)
+            .stateIn(this, SharingStarted.Eagerly, 1000)
         val showDirectSpeed = DataStore.configurationStore
             .booleanFlow(Key.SHOW_DIRECT_SPEED, true)
-            .stateIn(scope, SharingStarted.Eagerly, true)
+            .stateIn(this, SharingStarted.Eagerly, true)
         val profileTrafficStatistics = DataStore.configurationStore
             .booleanFlow(Key.PROFILE_TRAFFIC_STATISTICS, true)
-            .stateIn(scope, SharingStarted.Eagerly, true)
+            .stateIn(this, SharingStarted.Eagerly, true)
         // update database / 10s
         val persistEveryMs = 10_000L
 

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/AssetsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/AssetsScreenViewModel.kt
@@ -16,9 +16,9 @@ import fr.husi.database.DataStore
 import fr.husi.database.SagerDatabase
 import fr.husi.ktx.Logs
 import fr.husi.ktx.blankAsNull
+import fr.husi.ktx.onIoDispatcher
 import fr.husi.ktx.readableMessage
 import fr.husi.ktx.runOnDefaultDispatcher
-import fr.husi.ktx.runOnIoDispatcher
 import fr.husi.libcore.Libcore
 import fr.husi.resources.Res
 import fr.husi.resources.route_asset_no_update
@@ -309,7 +309,7 @@ internal class AssetsScreenViewModel(
             hiddenAssets.clear()
             pending
         }
-        runOnIoDispatcher {
+        onIoDispatcher {
             for (fileName in toDelete) {
                 val file = if (fileName.endsWith(".version.txt")) {
                     assetsDir.resolve(fileName)

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/configuration/ConfigurationScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/configuration/ConfigurationScreenViewModel.kt
@@ -472,7 +472,7 @@ class ConfigurationScreenViewModel : ViewModel() {
     fun updateOrder(groupId: Long, order: Int) = viewModelScope.launch {
         val group = uiState.value.groups.find { it.id == groupId } ?: return@launch
         if (group.order == order) return@launch
-        runOnIoDispatcher {
+        onIoDispatcher {
             GroupManager.updateGroup(
                 group.copy(
                     order = order,


### PR DESCRIPTION
Audit of every `runOnDefaultDispatcher` / `runOnIoDispatcher` / `runOnMainDispatcher` call site (~50 across 25 files) against whether `GlobalScope` is actually warranted.

Most uses are legitimate — work that must outlive its caller: ViewModel `save()`/`delete()` fired as a screen is dismissed, `commit()` called from `DisposableEffect.onDispose`, service teardown in `BaseService.stopRunner`, and the deliberate process-restart paths. Those are unchanged. This PR fixes the cases where `GlobalScope` was leaking work or masking a lifecycle problem.

## Changes

**`TrafficLooper` leaked collectors on every reconnect (the significant one)**

`loop()` shared three config flows with `stateIn(scope, SharingStarted.Eagerly, …)` into the *caller-supplied* scope, but `stop()` only cancels the loop `job`. The eager collectors therefore survived every connect/disconnect cycle — 3 leaked per cycle — and kept the parent job from ever completing. This hit both platforms: Android rooted that scope in `GlobalScope` via `ProxyInstance`, desktop in the never-cancelled `DesktopServiceRuntime` scope. They now share into the loop's own `coroutineScope`, so cancelling `job` tears them down.

**`ProxyInstance` no longer hangs the looper off `GlobalScope`**

It owns a `CoroutineScope(Dispatchers.Default + SupervisorJob())`, passes that to the looper, and cancels it in `close()`.

**`PublicDatabase` ran Room on the wrong pool**

`setQueryExecutor { runOnDefaultDispatcher { it.run() } }` put blocking SQLite calls on `Dispatchers.Default` (parallelism = CPU count) and spun a fresh `GlobalScope` coroutine per runnable. Replaced with `Dispatchers.IO.asExecutor()`.

**Two escapes from an enclosing coroutine**

`AssetsScreenViewModel.commit` nested `runOnIoDispatcher` inside `runOnDefaultDispatcher`, and `ConfigurationScreenViewModel.updateOrder` launched into `GlobalScope` from inside `viewModelScope.launch`. Both switched to `onIoDispatcher`, matching how the sibling functions in those same files are already written (`RouteScreenViewModel.commit`, `GroupProfilesHolderViewModel.commit`, `clearTrafficStatistics`, …).

**`AppChangeReceiver` needed `goAsync()`**

A coroutine does not keep the process alive past `onReceive`, so the per-app-proxy update could be killed before it wrote. Now wrapped in `goAsync()` with `finish()` in a `finally`.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` — **BUILD SUCCESSFUL** (covers the `commonMain` changes: `TrafficLooper`, `AssetsScreenViewModel`, `ConfigurationScreenViewModel`).
- The three `androidMain` changes (`ProxyInstance`, `PublicDatabase`, `AppChangeReceiver`) were **not compiled** — no Android SDK/NDK in the environment used, so `libcore.aar` could not be produced. They are small and use only standard APIs, but CI should be the confirmation.
- No runtime/on-device verification of the leak fix.

## Not addressed

`ScannerActivityViewModel` (lines 131/150/182) runs its import on `GlobalScope` while emitting failure messages via `viewModelScope.launch`. Once the Activity finishes, `viewModelScope` is cancelled and the user never sees the error, though the import keeps running. Fixing it means choosing between moving the import into `viewModelScope` (cancels the import when the screen closes) or routing the message through a global channel — a behavioural call, so left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZqXogoqGDUCASrPrxtokV)_