### PR TITLE
fix(OpenConnect): resolve with the DNS servers pushed by the server

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -251,6 +251,8 @@
     <string name="openconnect_reported_os">Reported OS</string>
     <string name="openconnect_allow_insecure_crypto">Allow Legacy Cryptography</string>
     <string name="local_hostname">Local Hostname</string>
+    <string name="use_tunnel_dns">Use DNS Pushed by Server</string>
+    <string name="use_tunnel_dns_summary">Resolve proxied domains with the DNS servers, search domains and split DNS rules pushed by the server, like the official client does. Disable it to keep using the remote DNS of the app.</string>
     <string name="tls_server_name">TLS Server Name</string>
     <string name="tls_peer_fingerprint">TLS Peer Fingerprint</string>
     <string name="vpn_server_url">Server URL</string>

--- a/composeApp/src/commonMain/kotlin/fr/husi/fmt/ConfigBuilder.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/fmt/ConfigBuilder.kt
@@ -114,6 +114,7 @@ const val TAG_DNS_LOCAL = "dns-local"
 const val TAG_DNS_FAKE = "dns-fake"
 const val TAG_DNS_HOSTS = "dns-hosts"
 const val TAG_DNS_MDNS = "dns-mdns"
+const val TAG_DNS_TUNNEL = "dns-tunnel"
 const val TAG_SERVICE_ANCHOR = "service-anchor"
 
 const val LOCALHOST4 = "127.0.0.1"
@@ -262,6 +263,15 @@ fun buildConfig(
             ?.takeIf { it.isNotEmpty() }
     }
     val externalIndexMap = ArrayList<IndexEntity>()
+
+    // VPN endpoints (OpenConnect/OpenVPN) whose pushed DNS servers should be used:
+    // outbound tag to sing-box DNS server type.
+    val tunnelDNSEndpoints = LinkedHashMap<String, String>()
+
+    // The endpoint that the main chain exits from, if its pushed DNS servers
+    // should replace the remote DNS.
+    var tunnelDNSExitTag: String? = null
+
     val networkStrategy = DataStore.networkStrategy
     val networkInterfaceStrategy = DataStore.networkInterfaceType
     val networkPreferredInterfaces = DataStore.networkPreferredInterfaces.toList()
@@ -673,6 +683,28 @@ fun buildConfig(
                 currentOutbound["tag"] = tagOut
                 tagMap[proxyEntity.id] = tagOut
                 outboundsByTag[tagOut] = currentOutbound
+
+                // OpenConnect and OpenVPN servers push their own DNS servers, search domains
+                // and split DNS rules. Only the tunnel can reach them, so their DNS is
+                // exposed as a DNS server of the endpoint.
+                if (!forTest) {
+                    val tunnelDNSType = when {
+                        bean is OpenConnectBean && bean.useTunnelDNS ->
+                            SingBoxOptions.DNS_TYPE_OPENCONNECT
+
+                        bean is OpenVPNBean && bean.useTunnelDNS ->
+                            SingBoxOptions.DNS_TYPE_OPENVPN
+
+                        else -> null
+                    }
+                    if (tunnelDNSType != null) {
+                        tunnelDNSEndpoints[tagOut] = tunnelDNSType
+                        // The last profile of the chain is the one traffic exits from.
+                        if (chainId == 0L && index == profileList.lastIndex) {
+                            tunnelDNSExitTag = tagOut
+                        }
+                    }
+                }
 
                 // External proxy need a direct inbound to forward the traffic
                 // For external proxy software, their traffic must goes to sing-box to use protected fd.
@@ -1202,11 +1234,33 @@ fun buildConfig(
             }
         }
 
+        // VPN endpoint DNS objects: endpoint tag to DNS server tag.
+        val tunnelDNSServerTags = LinkedHashMap<String, String>()
+        tunnelDNSExitTag?.let { exitTag ->
+            // Traffic exits from a VPN endpoint, so the servers it pushes take the place of
+            // the remote DNS: they are the only ones reachable through the tunnel.
+            tunnelDNSServerTags[exitTag] = TAG_DNS_REMOTE
+        }
+        for (endpointTag in tunnelDNSEndpoints.keys) {
+            if (endpointTag in tunnelDNSServerTags) continue
+            tunnelDNSServerTags[endpointTag] = "$TAG_DNS_TUNNEL-${tunnelDNSServerTags.size}"
+        }
+        for ((endpointTag, serverTag) in tunnelDNSServerTags) {
+            dns!!.servers!!.add(
+                buildEndpointDNSServer(
+                    type = tunnelDNSEndpoints.getValue(endpointTag),
+                    tag = serverTag,
+                    endpoint = endpointTag,
+                ),
+            )
+        }
+
         // remote dns obj
-        remoteDns.firstOrNull()?.let {
+        if (tunnelDNSExitTag == null) {
+            val remote = remoteDns.firstOrNull() ?: error("missing remote DNS")
             dns!!.servers!!.add(
                 buildDNSServer(
-                    it,
+                    remote,
                     mainTag,
                     TAG_DNS_REMOTE,
                     DomainResolveOptions().apply {
@@ -1214,7 +1268,7 @@ fun buildConfig(
                     },
                 ),
             )
-        } ?: error("missing remote DNS")
+        }
 
         // add directDNS objects here
         directDNS.firstOrNull()?.let {
@@ -1360,6 +1414,12 @@ fun buildConfig(
                     },
                 )
                 addPreferredDNSRule(TAG_DNS_MDNS)
+            }
+
+            // The domains pushed by a VPN endpoint (search domains and split DNS) only
+            // resolve inside its tunnel, so they win over the local resolver.
+            for (serverTag in tunnelDNSServerTags.values) {
+                addPreferredDNSRule(serverTag)
             }
 
             dnsHosts?.let {

--- a/composeApp/src/commonMain/kotlin/fr/husi/fmt/SingBoxOptions.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/fmt/SingBoxOptions.kt
@@ -103,6 +103,8 @@ object SingBoxOptions {
     const val DNS_TYPE_FAKEIP = "fakeip"
     const val DNS_TYPE_HOSTS = "hosts"
     const val DNS_TYPE_MDNS = "mdns"
+    const val DNS_TYPE_OPENCONNECT = "openconnect"
+    const val DNS_TYPE_OPENVPN = "openvpn"
 
     const val TUN_DNS_MODE_DISABLED = "disabled"
     const val TUN_DNS_MODE_NATIVE = "native"
@@ -6023,6 +6025,34 @@ object SingBoxOptions {
 
         @JvmField
         var `interface`: MutableList<String>? = null
+
+    }
+
+    @KxsSerializable
+    open class NewDNSServerOptions_OpenConnectDNSServerOptions : NewDNSServerOptions() {
+
+        @JvmField
+        var endpoint: String? = null
+
+        @JvmField
+        var accept_default_resolvers: Boolean? = null
+
+        @JvmField
+        var accept_search_domain: Boolean? = null
+
+    }
+
+    @KxsSerializable
+    open class NewDNSServerOptions_OpenVPNDNSServerOptions : NewDNSServerOptions() {
+
+        @JvmField
+        var endpoint: String? = null
+
+        @JvmField
+        var accept_default_resolvers: Boolean? = null
+
+        @JvmField
+        var accept_search_domain: Boolean? = null
 
     }
 

--- a/composeApp/src/commonMain/kotlin/fr/husi/fmt/SingBoxOptionsUtil.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/fmt/SingBoxOptionsUtil.kt
@@ -6,6 +6,8 @@ import fr.husi.fmt.SingBoxOptions.MyOptions
 import fr.husi.fmt.SingBoxOptions.MyRouteOptions
 import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions
 import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions_LocalDNSServerOptions
+import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions_OpenConnectDNSServerOptions
+import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions_OpenVPNDNSServerOptions
 import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions_RemoteDNSServerOptions
 import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions_RemoteHTTPSDNSServerOptions
 import fr.husi.fmt.SingBoxOptions.NewDNSServerOptions_RemoteTLSDNSServerOptions
@@ -472,6 +474,34 @@ fun buildDNSServer(
         }
 
     }.also {
+        it.tag = tag
+    }
+}
+
+/**
+ * Builds a DNS server resolving with the DNS servers pushed by the VPN [endpoint],
+ * like the official OpenConnect and OpenVPN clients do.
+ *
+ * [type] must be [SingBoxOptions.DNS_TYPE_OPENCONNECT] or [SingBoxOptions.DNS_TYPE_OPENVPN].
+ * Only one such DNS server is allowed per endpoint.
+ */
+fun buildEndpointDNSServer(type: String, tag: String, endpoint: String): NewDNSServerOptions {
+    return when (type) {
+        SingBoxOptions.DNS_TYPE_OPENCONNECT -> NewDNSServerOptions_OpenConnectDNSServerOptions().also {
+            it.endpoint = endpoint
+            it.accept_default_resolvers = true
+            it.accept_search_domain = true
+        }
+
+        SingBoxOptions.DNS_TYPE_OPENVPN -> NewDNSServerOptions_OpenVPNDNSServerOptions().also {
+            it.endpoint = endpoint
+            it.accept_default_resolvers = true
+            it.accept_search_domain = true
+        }
+
+        else -> error("not an endpoint DNS type: $type")
+    }.also {
+        it.type = type
         it.tag = tag
     }
 }

--- a/composeApp/src/commonMain/kotlin/fr/husi/fmt/openconnect/OpenConnectBean.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/fmt/openconnect/OpenConnectBean.kt
@@ -59,8 +59,14 @@ class OpenConnectBean : AbstractBean() {
     /** Answers remembered from interactive authentication, replayed on reconnect. */
     var formEntries: List<OpenConnectFormEntry> = emptyList()
 
+    /**
+     * Resolve proxied domains with the DNS servers pushed by the server,
+     * instead of the app's remote DNS.
+     */
+    var useTunnelDNS: Boolean = true
+
     override fun serialize(output: ByteBufferOutput) {
-        output.writeInt(2)
+        output.writeInt(3)
         super.serialize(output)
         output.writeString(server)
         output.writeString(flavor)
@@ -89,6 +95,9 @@ class OpenConnectBean : AbstractBean() {
         output.writeBoolean(tlsInsecure)
         output.writeString(tlsServerName)
         output.writeString(tlsPeerFingerprint)
+
+        // version 3
+        output.writeBoolean(useTunnelDNS)
     }
 
     override fun deserialize(input: ByteBufferInput) {
@@ -122,6 +131,10 @@ class OpenConnectBean : AbstractBean() {
             tlsInsecure = input.readBoolean()
             tlsServerName = input.readString().orEmpty()
             tlsPeerFingerprint = input.readString().orEmpty()
+        }
+
+        if (version >= 3) {
+            useTunnelDNS = input.readBoolean()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/fr/husi/fmt/openvpn/OpenVPNBean.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/fmt/openvpn/OpenVPNBean.kt
@@ -30,8 +30,14 @@ class OpenVPNBean : AbstractBean() {
     var redirectGateway: Boolean = false
     var mtu: Int = 1500
 
+    /**
+     * Resolve proxied domains with the DNS servers pushed by the server,
+     * instead of the app's remote DNS.
+     */
+    var useTunnelDNS: Boolean = true
+
     override fun serialize(output: ByteBufferOutput) {
-        output.writeInt(1)
+        output.writeInt(2)
         super.serialize(output)
         output.writeString(network)
         output.writeString(username)
@@ -55,6 +61,9 @@ class OpenVPNBean : AbstractBean() {
 
         // version 1
         output.writeString(cipher)
+
+        // version 2
+        output.writeBoolean(useTunnelDNS)
     }
 
     override fun deserialize(input: ByteBufferInput) {
@@ -82,6 +91,10 @@ class OpenVPNBean : AbstractBean() {
 
         if (version >= 1) {
             cipher = input.readString().orEmpty()
+        }
+
+        if (version >= 2) {
+            useTunnelDNS = input.readBoolean()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenConnectSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenConnectSettingsScreen.kt
@@ -48,6 +48,8 @@ import fr.husi.resources.router
 import fr.husi.resources.security_settings
 import fr.husi.resources.tls_peer_fingerprint
 import fr.husi.resources.tls_server_name
+import fr.husi.resources.use_tunnel_dns
+import fr.husi.resources.use_tunnel_dns_summary
 import fr.husi.resources.user_agent
 import fr.husi.resources.username
 import fr.husi.resources.vpn_key
@@ -211,6 +213,14 @@ private fun LazyListScope.openConnectSettings(
             valueToText = { it },
             summary = { Text(contentOrUnset(state.localHostname)) },
             icon = { MaskedIcon(Res.drawable.dns, IconMaskColors.IconWarmGray) },
+        )
+        PreferenceDivider()
+        SwitchPreference(
+            value = state.useTunnelDNS,
+            onValueChange = viewModel::setUseTunnelDNS,
+            title = { Text(stringResource(Res.string.use_tunnel_dns)) },
+            summary = { Text(stringResource(Res.string.use_tunnel_dns_summary)) },
+            icon = { MaskedIcon(Res.drawable.dns, IconMaskColors.IconLightGreen) },
         )
     }
     item("category_tls") { PreferenceCategory(text = { Text(stringResource(Res.string.security_settings)) }) }

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenConnectSettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenConnectSettingsViewModel.kt
@@ -22,6 +22,7 @@ internal data class OpenConnectUiState(
     val userAgent: String = "",
     val localHostname: String = "",
     val allowInsecureCrypto: Boolean = false,
+    val useTunnelDNS: Boolean = true,
     val tlsInsecure: Boolean = false,
     val tlsServerName: String = "",
     val tlsPeerFingerprint: String = "",
@@ -57,6 +58,7 @@ internal class OpenConnectSettingsViewModel : ProfileEditorViewModel<OpenConnect
                 userAgent = userAgent,
                 localHostname = localHostname,
                 allowInsecureCrypto = allowInsecureCrypto,
+                useTunnelDNS = useTunnelDNS,
                 tlsInsecure = tlsInsecure,
                 tlsServerName = tlsServerName,
                 tlsPeerFingerprint = tlsPeerFingerprint,
@@ -85,6 +87,7 @@ internal class OpenConnectSettingsViewModel : ProfileEditorViewModel<OpenConnect
         userAgent = it.userAgent
         localHostname = it.localHostname
         allowInsecureCrypto = it.allowInsecureCrypto
+        useTunnelDNS = it.useTunnelDNS
         tlsInsecure = it.tlsInsecure
         tlsServerName = it.tlsServerName
         tlsPeerFingerprint = it.tlsPeerFingerprint
@@ -148,6 +151,10 @@ internal class OpenConnectSettingsViewModel : ProfileEditorViewModel<OpenConnect
 
     fun setAllowInsecureCrypto(allow: Boolean) {
         mutableUiState.update { it.copy(allowInsecureCrypto = allow) }
+    }
+
+    fun setUseTunnelDNS(value: Boolean) {
+        mutableUiState.update { it.copy(useTunnelDNS = value) }
     }
 
     fun setTlsInsecure(value: Boolean) {

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenVPNSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenVPNSettingsScreen.kt
@@ -55,6 +55,8 @@ import fr.husi.resources.security_settings
 import fr.husi.resources.server_address
 import fr.husi.resources.server_port
 import fr.husi.resources.sni
+import fr.husi.resources.use_tunnel_dns
+import fr.husi.resources.use_tunnel_dns_summary
 import fr.husi.resources.username
 import fr.husi.resources.vpn_key
 import fr.husi.resources.wifi
@@ -293,6 +295,14 @@ private fun LazyListScope.openVPNSettings(
             onValueChange = viewModel::setRedirectGateway,
             title = { Text(stringResource(Res.string.openvpn_redirect_gateway)) },
             icon = { MaskedIcon(Res.drawable.route, IconMaskColors.IconLightBlue) },
+        )
+        PreferenceDivider()
+        SwitchPreference(
+            value = state.useTunnelDNS,
+            onValueChange = viewModel::setUseTunnelDNS,
+            title = { Text(stringResource(Res.string.use_tunnel_dns)) },
+            summary = { Text(stringResource(Res.string.use_tunnel_dns_summary)) },
+            icon = { MaskedIcon(Res.drawable.dns, IconMaskColors.IconLightGreen) },
         )
     }
     item("category_tls") { PreferenceCategory(text = { Text(stringResource(Res.string.security_settings)) }) }

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenVPNSettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/profile/OpenVPNSettingsViewModel.kt
@@ -33,6 +33,7 @@ internal data class OpenVPNUiState(
     val auth: String = "",
     val compression: String = "",
     val redirectGateway: Boolean = false,
+    val useTunnelDNS: Boolean = true,
     val mtu: Int = 1500,
 ) : ProfileEditorUiState
 
@@ -69,6 +70,7 @@ internal class OpenVPNSettingsViewModel : ProfileEditorViewModel<OpenVPNBean>() 
                 auth = auth,
                 compression = compression,
                 redirectGateway = redirectGateway,
+                useTunnelDNS = useTunnelDNS,
                 mtu = mtu,
             )
         }
@@ -99,6 +101,7 @@ internal class OpenVPNSettingsViewModel : ProfileEditorViewModel<OpenVPNBean>() 
         auth = it.auth
         compression = it.compression
         redirectGateway = it.redirectGateway
+        useTunnelDNS = it.useTunnelDNS
         mtu = it.mtu
     }
 
@@ -201,6 +204,10 @@ internal class OpenVPNSettingsViewModel : ProfileEditorViewModel<OpenVPNBean>() 
 
     fun setRedirectGateway(enabled: Boolean) {
         mutableUiState.update { it.copy(redirectGateway = enabled) }
+    }
+
+    fun setUseTunnelDNS(value: Boolean) {
+        mutableUiState.update { it.copy(useTunnelDNS = value) }
     }
 
     fun setMtu(value: Int) {

--- a/composeApp/src/commonTest/kotlin/fr/husi/fmt/ConfigBuilderTest.kt
+++ b/composeApp/src/commonTest/kotlin/fr/husi/fmt/ConfigBuilderTest.kt
@@ -9,6 +9,7 @@ import fr.husi.database.RuleEntity
 import fr.husi.database.SagerDatabase
 import fr.husi.fmt.internal.ChainBean
 import fr.husi.fmt.internal.ProxySetBean
+import fr.husi.fmt.openconnect.OpenConnectBean
 import fr.husi.fmt.socks.SOCKSBean
 import fr.husi.ktx.applyDefaultValues
 import fr.husi.platform.PlatformInfo
@@ -781,6 +782,64 @@ class ConfigBuilderTest : HusiKoinTest() {
         )
     }
 
+    @Test
+    fun `buildConfig should resolve with DNS pushed by OpenConnect endpoint`() = runBlocking {
+        DataStore.remoteDns = "tcp://dns.example.com"
+
+        val group = ProxyGroup(name = "group").applyDefaultValues()
+        group.id = SagerDatabase.groupDao.createGroup(group)
+
+        val proxy = createOpenConnectProxy(
+            groupId = group.id,
+            order = 1,
+            name = "vpn",
+        )
+
+        val result = buildConfig(proxy)
+        val dnsServers = parseDnsServers(result)
+        val remote = assertNotNull(dnsServers[TAG_DNS_REMOTE])
+
+        assertEquals(SingBoxOptions.DNS_TYPE_OPENCONNECT, remote["type"]?.jsonPrimitive?.content)
+        assertEquals("vpn", remote["endpoint"]?.jsonPrimitive?.content)
+        assertEquals("true", remote["accept_default_resolvers"]?.jsonPrimitive?.content)
+        assertEquals("true", remote["accept_search_domain"]?.jsonPrimitive?.content)
+        assertEquals(null, remote["detour"])
+        // Only one DNS server is allowed per endpoint.
+        assertEquals(
+            1,
+            dnsServers.count { it.value["endpoint"]?.jsonPrimitive?.content == "vpn" },
+        )
+
+        val preferredRule = parseDnsRules(result).first {
+            it["preferred_by"]?.jsonArray?.map { item -> item.jsonPrimitive.content } ==
+                listOf(TAG_DNS_REMOTE)
+        }
+        assertEquals(TAG_DNS_REMOTE, preferredRule["server"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `buildConfig should keep remote DNS when OpenConnect tunnel DNS is disabled`() = runBlocking {
+        DataStore.remoteDns = "tcp://dns.example.com"
+
+        val group = ProxyGroup(name = "group").applyDefaultValues()
+        group.id = SagerDatabase.groupDao.createGroup(group)
+
+        val proxy = createOpenConnectProxy(
+            groupId = group.id,
+            order = 1,
+            name = "vpn",
+            useTunnelDNS = false,
+        )
+
+        val dnsServers = parseDnsServers(buildConfig(proxy))
+        val remote = assertNotNull(dnsServers[TAG_DNS_REMOTE])
+
+        assertEquals(SingBoxOptions.DNS_TYPE_TCP, remote["type"]?.jsonPrimitive?.content)
+        assertEquals("dns.example.com", remote["server"]?.jsonPrimitive?.content)
+        assertEquals("vpn", remote["detour"]?.jsonPrimitive?.content)
+        assertEquals(0, dnsServers.count { it.value["endpoint"] != null })
+    }
+
     private fun parseOutbounds(result: ConfigBuildResult) =
         Json.parseToJsonElement(result.config).jsonObject["outbounds"]!!
             .jsonArray
@@ -824,6 +883,23 @@ class ConfigBuilderTest : HusiKoinTest() {
                 this.name = name
                 serverAddress = host
                 serverPort = port
+            }.applyDefaultValues(),
+        )
+        proxy.id = SagerDatabase.proxyDao.addProxy(proxy)
+        return proxy
+    }
+
+    private suspend fun createOpenConnectProxy(
+        groupId: Long,
+        order: Long,
+        name: String,
+        useTunnelDNS: Boolean = true,
+    ): ProxyEntity {
+        val proxy = ProxyEntity(groupId = groupId, userOrder = order).putBean(
+            OpenConnectBean().apply {
+                this.name = name
+                server = "https://vpn.example.com"
+                this.useTunnelDNS = useTunnelDNS
             }.applyDefaultValues(),
         )
         proxy.id = SagerDatabase.proxyDao.addProxy(proxy)

--- a/libcore/cmd/boxoption/main.go
+++ b/libcore/cmd/boxoption/main.go
@@ -256,4 +256,6 @@ var newDNSServerList = []any{
 	option.RemoteHTTPSDNSServerOptions{},
 	option.FakeIPDNSServerOptions{},
 	option.MDNSDNSServerOptions{},
+	option.OpenConnectDNSServerOptions{},
+	option.OpenVPNDNSServerOptions{},
 }

--- a/libcore/cmd/internal/shared/proxy.go
+++ b/libcore/cmd/internal/shared/proxy.go
@@ -1,0 +1,100 @@
+package shared
+
+import (
+	"cmp"
+	"context"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/sagernet/sing-box/common/tls"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/protocol/http"
+	"github.com/sagernet/sing/protocol/socks"
+)
+
+var proxyEnvironments = []string{
+	"ALL_PROXY", "all_proxy",
+	"SOCKS_PROXY", "socks_proxy",
+	"HTTPS_PROXY", "https_proxy",
+	"HTTP_PROXY", "http_proxy",
+}
+
+// DialerFromEnv loads proxy dialer from environment.
+// If no proxy URL be set, it uses fallback dialer. If dialer is empty, it uses N.SystemDialer.
+// However, if it encounters any error when parsing proxy from URL, it returns all errors.
+func DialerFromEnv(ctx context.Context, fallback N.Dialer) (N.Dialer, error) {
+	var errs []error
+	for _, env := range proxyEnvironments {
+		raw := os.Getenv(env)
+		if raw == "" {
+			continue
+		}
+		dialer, err := proxyFromURL(ctx, raw)
+		if err != nil {
+			errs = append(errs, E.Cause(err, "parse proxy from env: ", env))
+			continue
+		}
+		return dialer, nil
+	}
+	if len(errs) == 0 {
+		return cmp.Or[N.Dialer](fallback, N.SystemDialer), nil
+	}
+	return nil, E.Cause(E.Errors(errs...), "all env failed")
+}
+
+func proxyFromURL(ctx context.Context, raw string) (N.Dialer, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, E.Cause(err, "parse URL")
+	}
+	if u.Host == "" {
+		return nil, E.New("missing host")
+	}
+	var username, password string
+	if user := u.User; user != nil {
+		username = user.Username()
+		password, _ = user.Password()
+	}
+	scheme := strings.TrimRight(u.Scheme, "h") // curl private "h" suffix for socks remote resolve
+	switch scheme {
+	case "http":
+		return http.NewClient(http.Options{
+			Dialer:   N.SystemDialer,
+			Server:   M.ParseSocksaddr(u.Host),
+			Username: username,
+			Password: password,
+			Path:     u.Path,
+		}), nil
+	case "https":
+		tlsConfig := common.Must1(tls.NewSTDClient(ctx, logger.NOP(), u.Host, option.OutboundTLSOptions{
+			Enabled: true,
+		}))
+		dialer := tls.NewDialer(N.SystemDialer, tlsConfig)
+		return http.NewClient(http.Options{
+			Dialer:   dialer,
+			Server:   M.ParseSocksaddr(u.Host),
+			Username: username,
+			Password: password,
+			Path:     u.Path,
+		}), nil
+	case "socks", "socks4", "socks4a", "socks5":
+		var version socks.Version
+		switch scheme {
+		case "socks", "socks4":
+			version = socks.Version4
+		case "socks4a":
+			version = socks.Version4A
+		case "socks5":
+			version = socks.Version5
+		}
+		return socks.NewClient(N.SystemDialer, M.ParseSocksaddr(u.Host), version, username, password), nil
+	default:
+		return nil, E.New("unsupported scheme")
+	}
+}

--- a/libcore/cmd/internal/shared/proxy_test.go
+++ b/libcore/cmd/internal/shared/proxy_test.go
@@ -1,0 +1,196 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func dialerTypeName(t *testing.T, d N.Dialer) string {
+	t.Helper()
+	return fmt.Sprintf("%T", d)
+}
+
+func TestProxyFromURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		raw         string
+		wantErr     bool
+		errContains string
+		typeContain string
+	}{
+		{
+			name:        "http with auth",
+			raw:         "http://user:pass@example.com:8080/proxy",
+			typeContain: "http",
+		},
+		{
+			name: "http without auth",
+			raw:  "http://example.com:8080",
+		},
+		{
+			name:        "https with auth",
+			raw:         "https://user:pass@example.com:443",
+			typeContain: "http",
+		},
+		{
+			name:        "socks5 with auth",
+			raw:         "socks5://user:pass@example.com:1080",
+			typeContain: "socks",
+		},
+		{
+			name: "socks4",
+			raw:  "socks4://example.com:1080",
+		},
+		{
+			name: "socks4a",
+			raw:  "socks4a://example.com:1080",
+		},
+		{
+			name: "socks bare",
+			raw:  "socks://example.com:1080",
+		},
+		{
+			name:        "socks5h trims curl h suffix",
+			raw:         "socks5h://example.com:1080",
+			typeContain: "socks",
+		},
+		{
+			name:        "unsupported scheme",
+			raw:         "ftp://user:pass@example.com:21",
+			wantErr:     true,
+			errContains: "unsupported scheme",
+		},
+		{
+			name:        "missing host",
+			raw:         "http:///no-host-here",
+			wantErr:     true,
+			errContains: "missing host",
+		},
+		{
+			name:        "invalid url",
+			raw:         "http://%zz",
+			wantErr:     true,
+			errContains: "parse URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := proxyFromURL(context.Background(), tt.raw)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, d)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			if tt.typeContain != "" {
+				assert.Contains(t, strings.ToLower(dialerTypeName(t, d)), tt.typeContain)
+			}
+		})
+	}
+}
+
+func TestDialerFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		envs        map[string]string
+		fallback    N.Dialer
+		wantErr     bool
+		errContains string
+		typeContain string
+		wantSame    N.Dialer
+	}{
+		{
+			name:     "no env set returns fallback",
+			envs:     map[string]string{},
+			fallback: N.SystemDialer,
+			wantSame: N.SystemDialer,
+		},
+		{
+			name:     "no env set no fallback returns system dialer",
+			envs:     map[string]string{},
+			fallback: nil,
+			wantSame: N.SystemDialer,
+		},
+		{
+			name: "valid http proxy",
+			envs: map[string]string{
+				"HTTP_PROXY": "http://example.com:8080",
+			},
+		},
+		{
+			name: "priority all_proxy over http_proxy",
+			envs: map[string]string{
+				"ALL_PROXY":  "socks5://example.com:1080",
+				"HTTP_PROXY": "http://example.com:8080",
+			},
+			typeContain: "socks",
+		},
+		{
+			name: "skips invalid then uses valid",
+			envs: map[string]string{
+				"ALL_PROXY":  "ftp://example.com:21",
+				"HTTP_PROXY": "http://example.com:8080",
+			},
+		},
+		{
+			name: "all invalid returns error",
+			envs: map[string]string{
+				"ALL_PROXY":  "ftp://example.com:21",
+				"HTTP_PROXY": "ftp://example.com:21",
+			},
+			wantErr:     true,
+			errContains: "all env failed",
+		},
+		{
+			name: "lowercase env var works",
+			envs: map[string]string{
+				"http_proxy": "http://example.com:8080",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, env := range proxyEnvironments {
+				t.Setenv(env, "")
+			}
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+
+			d, err := DialerFromEnv(context.Background(), tt.fallback)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, d)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, d)
+			if tt.wantSame != nil {
+				assert.Same(t, tt.wantSame, d)
+			}
+			if tt.typeContain != "" {
+				assert.Contains(t, strings.ToLower(dialerTypeName(t, d)), tt.typeContain)
+			}
+		})
+	}
+}

--- a/libcore/cmd/licencecollect/main.go
+++ b/libcore/cmd/licencecollect/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
@@ -17,10 +18,13 @@ import (
 	"time"
 
 	_ "libcore" // Import dependencies
+	"libcore/cmd/internal/shared"
 
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing/common"
 	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
 
 	"codeberg.org/xchacha20-poly1305/pkgsite-go"
 )
@@ -68,7 +72,20 @@ func main() {
 		return
 	}
 
-	client := pkgsite.NewClient()
+	dialer, err := shared.DialerFromEnv(ctx, nil)
+	if err != nil {
+		log.WarnContext(ctx, err)
+		dialer = N.SystemDialer
+	}
+	client := pkgsite.NewClient(
+		pkgsite.WithHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					return dialer.DialContext(ctx, network, M.ParseSocksaddr(addr))
+				},
+			},
+		}),
+	)
 	libraries := make([]Library, 0, len(buildInfo.Deps)+1)
 	for _, dependency := range buildInfo.Deps {
 		library, err := resolveLibrary(ctx, client, dependency)
@@ -98,7 +115,7 @@ func main() {
 		return
 	}
 
-	err := json.NewEncoder(output).Encode(libraries)
+	err = json.NewEncoder(output).Encode(libraries)
 	if err != nil {
 		log.PanicContext(ctx, "encode json ", err)
 		return
@@ -209,7 +226,7 @@ func resolveModule(ctx context.Context, client *pkgsite.Client, modulePath strin
 	pkgModule, err := requestModuleWithRetry(ctx, client, modulePath, options)
 	// The module may not be recorded by pkgsite yet, ask it to fetch and retry once.
 	if isHTTPErrorCode(err, http.StatusNotFound) {
-		log.InfoContext(ctx, "not found, try to fetch ", modulePath)
+		log.WarnContext(ctx, "not found, try to fetch ", modulePath)
 		if fetchError := fetchModule(ctx, client, modulePath, options.Version); fetchError != nil {
 			log.ErrorContext(ctx, "also failed to fetch: ", fetchError)
 			return nil, err

--- a/libcore/cmd/ruleset_generate/main.go
+++ b/libcore/cmd/ruleset_generate/main.go
@@ -3,12 +3,15 @@ package main
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"flag"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"strings"
+
+	"libcore/cmd/internal/shared"
 
 	"github.com/sagernet/sing-box/common/geosite"
 	"github.com/sagernet/sing-box/common/srs"
@@ -17,6 +20,8 @@ import (
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common"
 	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -65,24 +70,40 @@ func main() {
 	buffer := bytes.NewBuffer(nil) // Shared buf.
 	buffer.Grow(finalBufCap)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dialer, err := shared.DialerFromEnv(ctx, nil)
+	if err != nil {
+		log.WarnContext(ctx, err)
+		dialer = N.SystemDialer
+	}
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, M.ParseSocksaddr(addr))
+			},
+		},
+		Timeout: C.TCPTimeout * 2,
+	}
+
 	if *geositeDate != "" {
-		if err := generateGeositeArchive(buffer); err != nil {
-			log.Fatal(err)
+		if err := generateGeositeArchive(ctx, httpClient, buffer); err != nil {
+			log.FatalContext(ctx, err)
 		}
 	}
 
-	log.Trace("Buf length: ", buffer.Len(), " cap: ", buffer.Cap())
+	log.TraceContext(ctx, "Buf length: ", buffer.Len(), " cap: ", buffer.Cap())
 
 	if *geoipDate != "" {
-		if err := generateGeoipArchive(buffer); err != nil {
-			log.Fatal(err)
+		if err := generateGeoipArchive(ctx, httpClient, buffer); err != nil {
+			log.FatalContext(ctx, err)
 		}
 	}
 
-	log.Trace("Buf length: ", buffer.Len(), " cap: ", buffer.Cap())
+	log.TraceContext(ctx, "Buf length: ", buffer.Len(), " cap: ", buffer.Cap())
 }
 
-func generateGeositeArchive(buffer *bytes.Buffer) error {
+func generateGeositeArchive(ctx context.Context, httpClient *http.Client, buffer *bytes.Buffer) error {
 	siteFile, err := os.Create(*geositeOutput)
 	if err != nil {
 		return err
@@ -96,7 +117,7 @@ func generateGeositeArchive(buffer *bytes.Buffer) error {
 	tWriter := tar.NewWriter(zWriter)
 	defer tWriter.Close()
 
-	geositeArchive, err := fetchGitHubArchive(geositeRepo, *geositeDate)
+	geositeArchive, err := fetchGitHubArchive(ctx, httpClient, geositeRepo, *geositeDate)
 	if err != nil {
 		return err
 	}
@@ -142,7 +163,7 @@ func generateGeositeArchive(buffer *bytes.Buffer) error {
 	return nil
 }
 
-func generateGeoipArchive(buf *bytes.Buffer) error {
+func generateGeoipArchive(ctx context.Context, httpClient *http.Client, buf *bytes.Buffer) error {
 	ipFile, err := os.Create(*geoipOutput)
 	if err != nil {
 		return err
@@ -156,7 +177,7 @@ func generateGeoipArchive(buf *bytes.Buffer) error {
 	tWriter := tar.NewWriter(zWriter)
 	defer tWriter.Close()
 
-	geoipData, err := fetchRelease(geoipRepo, *geoipDate, ipName)
+	geoipData, err := fetchRelease(ctx, httpClient, geoipRepo, *geoipDate, ipName)
 	if err != nil {
 		return err
 	}
@@ -198,10 +219,14 @@ func generateGeoipArchive(buf *bytes.Buffer) error {
 	return nil
 }
 
-func fetchRelease(repo, tag, name string) ([]byte, error) {
+func fetchRelease(ctx context.Context, httpClient *http.Client, repo, tag, name string) ([]byte, error) {
 	link := "https://github.com/" + repo + "/releases/download/" + tag + "/" + name
 
-	resp, err := http.Get(link)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
+	if err != nil {
+		return nil, E.Cause(err, "build http request")
+	}
+	resp, err := httpClient.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -213,13 +238,17 @@ func fetchRelease(repo, tag, name string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-func fetchGitHubArchive(repo, ref string) (io.ReadCloser, error) {
+func fetchGitHubArchive(ctx context.Context, httpClient *http.Client, repo, ref string) (io.ReadCloser, error) {
 	if !strings.HasPrefix(ref, "refs/") {
 		ref = "refs/tags/" + ref
 	}
 	link := "https://codeload.github.com/" + repo + "/tar.gz/" + ref
 
-	resp, err := http.Get(link)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
+	if err != nil {
+		return nil, E.Cause(err, "build http request")
+	}
+	resp, err := httpClient.Do(request)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes the "no traffic after connect" half of #836.

## Problem

The debug log attached to the issue shows the tunnel coming up fine
(`anyconnect tunnel established using cstp`) and then every name lookup dying
inside it:

```
dns: lookup failed for api.uymgg1.com: (exchange6: dial TCP connection:
  (context deadline exceeded | missing IPv6 local address) | exchange4: ...)
dns: lookup failed for cp.cloudflare.com: context deadline exceeded
```

The generated config resolves proxied domains with the remote DNS of the app
detoured through the endpoint:

```json
{ "type": "tcp", "tag": "dns-remote", "detour": "vpn.example.edu", "server": "dns.google" }
```

That gateway resolves `dns.google` to an internal address (`10.10.34.36`) and
drops DNS to it, so nothing resolves and no site loads, even though the tunnel
carries traffic (the one connection made to a literal IP got a real
`connection refused` from the corporate network, not a client error).

An OpenConnect or OpenVPN server pushes its own DNS servers, search domains
and split DNS rules, and on a corporate gateway they are usually the only
resolvers reachable through the tunnel — that is what the official clients
use. We never looked at them, although sing-box exposes them as a DNS server
bound to the endpoint.

## Changes

* `boxoption`: generate `NewDNSServerOptions_OpenConnectDNSServerOptions` and
  `NewDNSServerOptions_OpenVPNDNSServerOptions`, plus the two DNS type
  constants.
* `ConfigBuilder`: for OpenConnect and OpenVPN endpoints, emit a DNS server of
  the matching type with `accept_default_resolvers` and
  `accept_search_domain`. sing-box allows only one DNS server per endpoint, so
  at most one is emitted for each.
  * A `preferred_by` rule is added for it, ordered before the local resolver,
    because the pushed search domains and split DNS domains only resolve
    inside the tunnel.
  * When traffic exits from the endpoint, its pushed servers take the place of
    `dns-remote` instead of the remote DNS of the app.
* New per-profile switch `Use DNS Pushed by Server` (default on) for
  OpenConnect and OpenVPN, so a split tunnel gateway that only answers for its
  own domains and expects everything else to be resolved outside can keep the
  previous behaviour. Bean serialization versions bumped accordingly
  (OpenConnect 2 → 3, OpenVPN 1 → 2); older profiles read back with the switch
  on.
* Two `ConfigBuilderTest` cases cover both switch positions.

## Not covered here: the missing banner dialog

The other half of #836 cannot be fixed in this repository:

* Cisco's "Please Respond to Banner" is the post-connect CSTP banner
  (`X-CSTP-Banner`). `sing-openconnect` parses it and sing-box stores it in
  its transport configuration, but `adapter.OpenConnectTunnelInfo` has no
  banner field, so libcore has nothing to read and forward to the UI.
* An authentication form whose visible fields are all pre-filled or hidden is
  auto-submitted by `sing-openconnect` (`auth_form.go`), so a banner-only
  acknowledgement form never reaches us as a challenge. That acknowledgement
  still happens — it is not what blocks traffic.

The dialog already renders `challenge.banner` whenever a challenge carries
one, so surfacing the CSTP banner only needs the upstream field.

---
_Generated by [Claude Code](https://claude.ai/code/session_018bkHXKPAdLqRmgYfTEnLe9)_