### PR TITLE
ci: generate about libraries metadata in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: make libcore_android
+      - name: Generate about libraries metadata
+        run: make aboutlibraries_go aboutlibraries_android
       - name: Build Android app
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
@@ -135,6 +137,8 @@ jobs:
         env:
           CRONET_GO_ROOT: ${{ github.workspace }}/cronet-go
         run: make libcore_desktop DESKTOP_TARGETS=linux/amd64,linux/arm64,windows/amd64,windows/arm64,darwin/amd64,darwin/arm64 JNI_INCLUDE="$JNI_INCLUDE" DARWIN_SDK="$MACOS_SDK_PATH"
+      - name: Generate about libraries metadata
+        run: make aboutlibraries_go aboutlibraries_desktop
       - name: Build desktop packages
         run: |
           make desktop_package_linux DESKTOP_TARGET=linux/amd64


### PR DESCRIPTION
## Summary
- The release workflow built Android and desktop artifacts without ever running the `aboutlibraries` generation steps (`make aboutlibraries_go` / `aboutlibraries_android` / `aboutlibraries_desktop`), so the packaged `files/aboutlibraries.json` compose resource read by `LibrariesScreen.kt` was missing or stale in release builds.
- Added a "Generate about libraries metadata" step to the `android` job (after building Android libcore, before assembling the APK) and to the `desktop` job (after building desktop libcore, before packaging), matching how `make aboutlibraries` is meant to run per `Makefile`.

## Test plan
- [ ] Confirm the `Release` workflow runs the new steps successfully and produces a populated `aboutlibraries.json` in both Android and desktop artifacts.


---
_Generated by [Claude Code](https://claude.ai/code/session_019XXEZUnQSoC5LSisw5PETK)_