### PR TITLE
fix(openvpn): parse key-direction, inline credentials and bare compress

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/husi/fmt/openvpn/OpenVPNFmt.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/fmt/openvpn/OpenVPNFmt.kt
@@ -53,15 +53,15 @@ fun parseOpenVPNConfig(conf: String): OpenVPNBean {
             it.controlWrapType = directive.replace('-', '_')
             it.controlWrapKey = inlineBlocks[directive].orEmpty()
         }
+        // <auth-user-pass> holds the user name on the first line and the password on the second.
+        inlineBlocks["auth-user-pass"]?.lines()?.let { credentials ->
+            it.username = credentials.getOrNull(0)?.trim().orEmpty()
+            it.password = credentials.getOrNull(1)?.trim().orEmpty()
+        }
     }
     var foundRemote = false
 
-    for (rawLine in conf.lineSequence()) {
-        val line = rawLine.trim()
-        if (line.isEmpty() || line.startsWith("#") || line.startsWith(";") || line.startsWith("<")) {
-            continue
-        }
-
+    for (line in openVPNDirectiveLines(conf)) {
         val arguments = line.split(' ', '\t').filter { it.isNotEmpty() }
         val directive = arguments.first().lowercase()
         val values = arguments.drop(1)
@@ -89,12 +89,15 @@ fun parseOpenVPNConfig(conf: String): OpenVPNBean {
                 bean.controlWrapType = directive.replace('-', '_')
                 inlineBlocks[directive]?.let { key -> bean.controlWrapKey = key }
                 if (directive == "tls-auth") {
-                    bean.controlWrapDirection = when (values.getOrNull(1)) {
-                        "0" -> "server"
-                        "1" -> "client"
-                        else -> ""
+                    parseOpenVPNKeyDirection(values.getOrNull(1))?.let { direction ->
+                        bean.controlWrapDirection = direction
                     }
                 }
+            }
+
+            // Standalone key direction, used together with an inline <tls-auth> block.
+            "key-direction" -> parseOpenVPNKeyDirection(values.firstOrNull())?.let { direction ->
+                bean.controlWrapDirection = direction
             }
 
             "data-ciphers" -> bean.dataCiphers = values.joinToString("\n") { it.replace(':', '\n') }
@@ -104,7 +107,8 @@ fun parseOpenVPNConfig(conf: String): OpenVPNBean {
 
             "auth" -> bean.auth = values.firstOrNull().orEmpty()
 
-            "compress" -> bean.compression = values.firstOrNull().orEmpty()
+            // A bare `compress` enables the compression framing without compressing.
+            "compress" -> bean.compression = values.firstOrNull() ?: "stub"
 
             "redirect-gateway" -> bean.redirectGateway = true
 
@@ -137,8 +141,24 @@ fun parseOpenVPNConfig(conf: String): OpenVPNBean {
     check(bean.controlWrapType.isBlank() || bean.controlWrapKey.isNotBlank()) {
         "OpenVPN control channel protection requires an inline key block."
     }
+    // Only tls-auth is keyed per direction, the other wrappers reject a direction.
+    if (bean.controlWrapType != "tls_auth") bean.controlWrapDirection = ""
     return bean.applyDefaultValues()
 }
+
+/**
+ * Inline blocks holding raw material instead of directives.
+ * Blocks outside of this set, such as `<connection>`, wrap regular directives.
+ */
+private val openVPNMaterialBlocks = setOf(
+    "ca",
+    "cert",
+    "key",
+    "tls-auth",
+    "tls-crypt",
+    "tls-crypt-v2",
+    "auth-user-pass",
+)
 
 /**
 <ca>
@@ -146,7 +166,6 @@ xxxxxx
 </ca>
  */
 private fun parseOpenVPNInlineBlocks(conf: String): Map<String, String> {
-    val supportedBlockNames = setOf("ca", "cert", "key", "tls-auth", "tls-crypt", "tls-crypt-v2")
     val blocks = mutableMapOf<String, String>()
     var activeBlockName: String? = null
     val content = StringBuilder()
@@ -157,7 +176,7 @@ private fun parseOpenVPNInlineBlocks(conf: String): Map<String, String> {
         if (currentBlockName == null) {
             if (line.startsWith('<') && line.endsWith('>') && !line.startsWith("</")) {
                 val blockName = line.substring(1, line.length - 1).lowercase()
-                if (blockName in supportedBlockNames) {
+                if (blockName in openVPNMaterialBlocks) {
                     activeBlockName = blockName
                     content.clear()
                 }
@@ -173,6 +192,38 @@ private fun parseOpenVPNInlineBlocks(conf: String): Map<String, String> {
 
     check(activeBlockName == null) { "OpenVPN inline <$activeBlockName> block is not closed." }
     return blocks
+}
+
+/**
+ * Yields the trimmed directive lines of [conf], dropping comments and the content of material
+ * blocks, which could otherwise be mistaken for directives.
+ */
+private fun openVPNDirectiveLines(conf: String): Sequence<String> = sequence {
+    var closingTag: String? = null
+
+    for (rawLine in conf.lineSequence()) {
+        val line = rawLine.trim()
+        val currentClosingTag = closingTag
+        if (currentClosingTag != null) {
+            if (line.equals(currentClosingTag, ignoreCase = true)) closingTag = null
+            continue
+        }
+        if (line.isEmpty() || line.startsWith("#") || line.startsWith(";")) continue
+        if (line.startsWith('<') && line.endsWith('>')) {
+            if (!line.startsWith("</")) {
+                val blockName = line.substring(1, line.length - 1).lowercase()
+                if (blockName in openVPNMaterialBlocks) closingTag = "</$blockName>"
+            }
+            continue
+        }
+        yield(line)
+    }
+}
+
+private fun parseOpenVPNKeyDirection(value: String?): String? = when (value) {
+    "0" -> "server"
+    "1" -> "client"
+    else -> null
 }
 
 private fun parseOpenVPNNetwork(value: String): String {

--- a/composeApp/src/commonTest/kotlin/fr/husi/fmt/openvpn/OpenVPNFmtTest.kt
+++ b/composeApp/src/commonTest/kotlin/fr/husi/fmt/openvpn/OpenVPNFmtTest.kt
@@ -170,6 +170,130 @@ class OpenVPNFmtTest {
     }
 
     @Test
+    fun `parseOpenVPNConfig reads standalone key-direction`() {
+        val config = """
+            client
+            dev tun
+            proto udp
+            remote vpn.example.com 1194
+            remote-cert-tls server
+            auth-user-pass
+            cipher AES-256-CBC
+            auth SHA512
+            <ca>
+            test-ca
+            </ca>
+            key-direction 1
+            <tls-auth>
+            #
+            # 2048 bit OpenVPN static key
+            #
+            test-control-key
+            </tls-auth>
+        """.trimIndent()
+
+        val bean = assertNotNull(parseOpenVPNConfig(config))
+
+        assertEquals("vpn.example.com", bean.serverAddress)
+        assertEquals(1194, bean.serverPort)
+        assertEquals("udp", bean.network)
+        assertEquals("AES-256-CBC", bean.dataCiphers)
+        assertEquals("tls_auth", bean.controlWrapType)
+        assertEquals("client", bean.controlWrapDirection)
+        assertTrue(bean.controlWrapKey.contains("test-control-key"))
+    }
+
+    @Test
+    fun `parseOpenVPNConfig ignores key-direction without tls-auth`() {
+        val config = """
+            client
+            remote vpn.example.com 1194
+            key-direction 1
+            <ca>
+            test-ca
+            </ca>
+            <tls-crypt>
+            test-control-key
+            </tls-crypt>
+        """.trimIndent()
+
+        val bean = assertNotNull(parseOpenVPNConfig(config))
+
+        assertEquals("tls_crypt", bean.controlWrapType)
+        assertEquals("", bean.controlWrapDirection)
+    }
+
+    @Test
+    fun `parseOpenVPNConfig reads inline credentials`() {
+        val config = """
+            client
+            remote vpn.example.com 1194
+            compress
+            <auth-user-pass>
+            alice
+            secret
+            </auth-user-pass>
+            <ca>
+            test-ca
+            </ca>
+        """.trimIndent()
+
+        val bean = assertNotNull(parseOpenVPNConfig(config))
+
+        assertEquals("alice", bean.username)
+        assertEquals("secret", bean.password)
+        assertEquals("stub", bean.compression)
+    }
+
+    @Test
+    fun `parseOpenVPNConfig reads remote from connection block`() {
+        val config = """
+            client
+            dev tun
+            data-ciphers AES-256-GCM:AES-256-CBC
+
+            <connection>
+            remote 192.0.2.1 443 udp
+            nobind
+            connect-retry 5 5
+            </connection>
+
+            <connection>
+            remote 192.0.2.1 443 tcp-client
+            nobind
+            </connection>
+
+            <ca>
+            test-ca
+            </ca>
+        """.trimIndent()
+
+        val bean = assertNotNull(parseOpenVPNConfig(config))
+
+        assertEquals("192.0.2.1", bean.serverAddress)
+        assertEquals(443, bean.serverPort)
+        assertEquals("udp", bean.network)
+        assertEquals("AES-256-GCM\nAES-256-CBC", bean.dataCiphers)
+    }
+
+    @Test
+    fun `parseOpenVPNConfig ignores directive like lines inside material blocks`() {
+        val config = """
+            client
+            remote vpn.example.com 1194
+            <ca>
+            test-ca
+            auth SHA512
+            </ca>
+        """.trimIndent()
+
+        val bean = assertNotNull(parseOpenVPNConfig(config))
+
+        assertEquals("", bean.auth)
+        assertTrue(bean.certificate.contains("auth SHA512"))
+    }
+
+    @Test
     fun `parseOpenVPNConfig rejects missing trusted server certificate`() {
         val error = assertFailsWith<IllegalStateException> {
             parseOpenVPNConfig("remote vpn.example.com 443")


### PR DESCRIPTION
Closes #842

## Root cause

The three failing `.ovpn` files (Kaspersky, Surfshark) pair an inline `<tls-auth>` block with a **standalone `key-direction 1` directive**, instead of passing the direction as the second argument of `tls-auth`:

```
<tls-auth>
...
</tls-auth>
key-direction 1
```

`parseOpenVPNConfig` only read the direction from the argument form (`tls-auth <file> 1`), and a line starting with `<` was skipped entirely, so `controlWrapDirection` stayed empty. sing-box maps an empty `tls.control_wrap.direction` to `keyDirection = -1`, which makes the client sign control packets with **slot 0** of the static key — the slot the server itself sends from. The server's HMAC check fails and it drops every control packet silently, so the handshake never completes:

```
endpoint/openvpn-client[...]: session with ...:443 over udp failed; retrying in 1s: i/o timeout
connection: open connection to ... using outbound/openvpn-client[...]: endpoint is not ready yet
```

## Changes

- Parse `key-direction` as its own directive (`0` → `server`, `1` → `client`).
- Clear the direction when the control wrap is not `tls_auth` — sing-box rejects a direction for `tls_crypt` / `tls_crypt_v2`.
- Read the user name and password from an inline `<auth-user-pass>` block, so configs embedding credentials import with them filled in (reported as point 2 and 3 of the issue).
- Map a bare `compress` (used by the Kaspersky config) to the `stub` framing instead of leaving compression unset, which would desynchronize the data channel.
- Skip the content of material blocks (`<ca>`, `<cert>`, `<key>`, `<tls-*>`, `<auth-user-pass>`) while scanning directives, so their content can never be mistaken for a directive. Blocks wrapping real directives, such as `<connection>`, are still scanned.

## Tests

New cases in `OpenVPNFmtTest` cover the standalone `key-direction`, the direction being dropped for `tls_crypt`, inline credentials with a bare `compress`, a `remote` nested in `<connection>` blocks, and directive-looking lines inside `<ca>`.

`./gradlew :composeApp:desktopTest` — 404 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jnCbG9ZuEYU3ZMee7LDQL

---
_Generated by [Claude Code](https://claude.ai/code/session_012jnCbG9ZuEYU3ZMee7LDQL)_