### PR TITLE
fix(ui): show filter regex option in group subscription settings

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/GroupSettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/GroupSettingsScreen.kt
@@ -65,8 +65,10 @@ import fr.husi.resources.auto_update_delay
 import fr.husi.resources.close
 import fr.husi.resources.delete
 import fr.husi.resources.delete_group_prompt
+import fr.husi.resources.delete_sweep
 import fr.husi.resources.done
 import fr.husi.resources.emoji_symbols
+import fr.husi.resources.filter_regex
 import fr.husi.resources.flip_camera_android
 import fr.husi.resources.front_proxy
 import fr.husi.resources.grid_3x3
@@ -456,6 +458,21 @@ private fun LazyListScope.groupSettings(
                 textField = { value, onValueChange, onOk ->
                     LinkOrContentTextField(value, onValueChange, onOk)
                 },
+            )
+            PreferenceDivider()
+            TextFieldPreference(
+                value = uiState.subscriptionFilterNotRegex,
+                onValueChange = { viewModel.setSubscriptionFilterNotRegex(it) },
+                title = { Text(stringResource(Res.string.filter_regex)) },
+                textToValue = { it },
+                icon = {
+                    MaskedIcon(
+                        Res.drawable.delete_sweep,
+                        color = IconMaskColors.IconLightGreen,
+                    )
+                },
+                summary = { Text(contentOrUnset(uiState.subscriptionFilterNotRegex)) },
+                valueToText = { it },
             )
         }
         val supportsAge = uiState.subscriptionType == SubscriptionType.RAW


### PR DESCRIPTION
## Summary
- `GroupSettingsViewModel` already tracked `subscriptionFilterNotRegex` (read from/written to `SubscriptionBean.filterNotRegex`, and used by `GroupUpdater` to filter subscription proxies), but `GroupSettingsScreen` never rendered a control for it, so the option was unreachable from the group subscription settings UI.
- Added a `TextFieldPreference` for the filter regex, reusing the existing `filter_regex` string resource and `delete_sweep` icon already used for the equivalent field in `ProxySetSettingsScreen`.

## Test plan
- [x] `./gradlew :composeApp:compileCommonMainKotlinMetadata` passes (verifies the new Compose code, imports, and resource references compile).
- [ ] Manual verification in the running desktop/Android app that the "Filter (Regex)" field appears under a subscription group's settings and persists.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb8JZoSHwdqVFxCJ1Gg4jU)_