### PR TITLE
Add launcher tests and wire into Makefile/CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - buildSrc/**
       - composeApp/**
       - gradle/**
+      - launcher/**
       - libcore/**
       - library/**
   pull_request:
@@ -21,6 +22,7 @@ on:
       - buildSrc/**
       - composeApp/**
       - gradle/**
+      - launcher/**
       - libcore/**
       - library/**
 
@@ -86,6 +88,8 @@ jobs:
           CRONET_GO_ROOT: ${{ github.workspace }}/cronet-go
         run: |
           make libcore
+      - name: Test launcher
+        run: cd launcher && zig build test
       - name: Test Kotlin
         env:
           BUILD_PLUGIN: none

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,10 @@ rather than silently falling back.
 ## Tests & lint
 
 ```
-make test                # = test_gradle + test_go
+make test                # = test_gradle + test_go + test_launcher
 make test_gradle         # ./gradlew :composeApp:allTests (JUnit5)
 make test_go             # cd libcore && go test -v -count=1 ./...
+make test_launcher       # cd launcher && zig build test
 make lint_go             # GOOS=android golangci-lint run ./...
 make fmt_go              # gofumpt + gofmt + gci (run before committing Go)
 ```

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ NO_NAIVE_SCRIPT_ARG = $(if $(filter 1,$(NO_NAIVE)),--no-naive,)
 LAUNCHER_ZIG_TARGET = $(subst linux/amd64,x86_64-linux-musl,$(subst linux/arm64,aarch64-linux-musl,$(subst darwin/amd64,x86_64-macos,$(subst darwin/arm64,aarch64-macos,$(subst windows/amd64,x86_64-windows,$(subst windows/arm64,aarch64-windows,$(DESKTOP_TARGET)))))))
 LAUNCHER_ZIG_TARGET_ARG = $(if $(LAUNCHER_ZIG_TARGET),-Dtarget=$(LAUNCHER_ZIG_TARGET),)
 
-.PHONY: update libcore libcore_android libcore_desktop_common libcore_desktop aboutlibraries aboutlibraries_go aboutlibraries_android aboutlibraries_desktop apk apk_debug assets desktop desktop_release desktop_package desktop_package_linux desktop_package_linux_all desktop_package_macos desktop_package_windows desktop_package_windows_all desktop_uberjar launcher lint_go test_go plugin generate_option
+.PHONY: update libcore libcore_android libcore_desktop_common libcore_desktop aboutlibraries aboutlibraries_go aboutlibraries_android aboutlibraries_desktop apk apk_debug assets desktop desktop_release desktop_package desktop_package_linux desktop_package_linux_all desktop_package_macos desktop_package_windows desktop_package_windows_all desktop_uberjar launcher lint_go test_go test_launcher plugin generate_option
 
 build: libcore_android assets apk
 
@@ -134,13 +134,16 @@ fmt_go_install:
 	go install -v mvdan.cc/gofumpt@latest
 	go install -v github.com/daixiang0/gci@latest
 
-test: test_gradle test_go
+test: test_gradle test_go test_launcher
 
 test_gradle:
 	./gradlew :composeApp:allTests
 
 test_go:
 	cd libcore/ && go test -v -count=1 ./...
+
+test_launcher:
+	cd launcher && zig build test
 
 plugin:
 	BUILD_PLUGIN=$(PLUGIN) ./gradlew :plugin:$(PLUGIN):assembleFossRelease

--- a/launcher/src/main.zig
+++ b/launcher/src/main.zig
@@ -454,6 +454,241 @@ fn selectJavaCommand(io: Io, allocator: mem.Allocator, env_map: *process.Environ
     return allocator.dupe(u8, "java");
 }
 
+const testing_io: Io = std.testing.io;
+
+fn writeTempFile(tmp_dir: std.testing.TmpDir, sub_path: []const u8, content: []const u8) !void {
+    const file = try tmp_dir.dir.createFile(testing_io, sub_path, .{});
+    defer file.close(testing_io);
+    var buf: [4096]u8 = undefined;
+    var w = file.writer(testing_io, &buf);
+    try w.interface.writeAll(content);
+    try w.interface.flush();
+}
+
+fn tmpDirPath(tmp_dir: std.testing.TmpDir, allocator: mem.Allocator, sub_path: []const u8) ![]u8 {
+    var path_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const len = tmp_dir.dir.realPath(testing_io, &path_buf) catch return error.BadPath;
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ path_buf[0..len], sub_path });
+}
+
+test "readArgsFile: basic lines" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "test.conf", "-Xmx512m\n-Dfoo=bar\n");
+
+    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing_io, allocator, path, &list);
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqualStrings("-Xmx512m", list.items[0]);
+    try std.testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
+}
+
+test "readArgsFile: skips comments and blank lines" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "test.conf", "# comment\n\n-Xmx256m\n  # indented comment\n-Dfoo=1\n");
+
+    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing_io, allocator, path, &list);
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqualStrings("-Xmx256m", list.items[0]);
+    try std.testing.expectEqualStrings("-Dfoo=1", list.items[1]);
+}
+
+test "readArgsFile: no trailing newline" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "test.conf", "-Xmx128m");
+
+    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing_io, allocator, path, &list);
+    try std.testing.expectEqual(@as(usize, 1), list.items.len);
+    try std.testing.expectEqualStrings("-Xmx128m", list.items[0]);
+}
+
+test "readArgsFile: empty file" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "test.conf", "");
+
+    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing_io, allocator, path, &list);
+    try std.testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "readArgsFile: only comments" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "test.conf", "# comment 1\n# comment 2\n");
+
+    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing_io, allocator, path, &list);
+    try std.testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "readArgsFile: trims whitespace" {
+    const allocator = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "test.conf", "  -Xmx512m  \n\t-Dfoo=bar\t\n");
+
+    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing_io, allocator, path, &list);
+    try std.testing.expectEqual(@as(usize, 2), list.items.len);
+    try std.testing.expectEqualStrings("-Xmx512m", list.items[0]);
+    try std.testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
+}
+
+test "resolveArgsFile: prefers user path" {
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "user.conf", "a");
+    try writeTempFile(tmp_dir, "template.conf", "b");
+
+    const allocator = std.testing.allocator;
+    const user_path = try tmpDirPath(tmp_dir, allocator, "user.conf");
+    defer allocator.free(user_path);
+    const template_path = try tmpDirPath(tmp_dir, allocator, "template.conf");
+    defer allocator.free(template_path);
+
+    const result = resolveArgsFile(testing_io, user_path, template_path);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings(user_path, result.?);
+}
+
+test "resolveArgsFile: falls back to template" {
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(tmp_dir, "template.conf", "b");
+
+    const allocator = std.testing.allocator;
+    const user_path = try tmpDirPath(tmp_dir, allocator, "user.conf");
+    defer allocator.free(user_path);
+    const template_path = try tmpDirPath(tmp_dir, allocator, "template.conf");
+    defer allocator.free(template_path);
+
+    const result = resolveArgsFile(testing_io, user_path, template_path);
+    try std.testing.expect(result != null);
+    try std.testing.expectEqualStrings(template_path, result.?);
+}
+
+test "resolveArgsFile: returns null when neither exists" {
+    const result = resolveArgsFile(testing_io, "/nonexistent/user.conf", "/nonexistent/template.conf");
+    try std.testing.expect(result == null);
+}
+
+test "resolveConfigBase: linux uses XDG_CONFIG_HOME" {
+    if (native_os != .linux) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+    try env_map.put("XDG_CONFIG_HOME", "/custom/config");
+
+    const result = try resolveConfigBase(allocator, &env_map);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("/custom/config", result);
+}
+
+test "resolveConfigBase: linux falls back to HOME/.config" {
+    if (native_os != .linux) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+    try env_map.put("HOME", "/home/testuser");
+
+    const result = try resolveConfigBase(allocator, &env_map);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("/home/testuser/.config", result);
+}
+
+test "resolveUserHome: missing HOME returns error" {
+    const allocator = std.testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+
+    const result = resolveUserHome(allocator, &env_map);
+    try std.testing.expectError(error.MissingHome, result);
+}
+
+test "resolveUserConfigPaths: produces expected paths" {
+    if (native_os != .linux) return error.SkipZigTest;
+
+    const allocator = std.testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+    try env_map.put("XDG_CONFIG_HOME", "/tmp/testconfig");
+
+    const paths = try resolveUserConfigPaths(allocator, &env_map);
+    defer allocator.free(paths.java_opts_path);
+    defer allocator.free(paths.app_args_path);
+
+    try std.testing.expectEqualStrings("/tmp/testconfig/husi/desktop-java-opts.conf", paths.java_opts_path);
+    try std.testing.expectEqualStrings("/tmp/testconfig/husi/desktop-app-args.conf", paths.app_args_path);
+}
+
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
     const arena = init.arena;

--- a/launcher/src/main.zig
+++ b/launcher/src/main.zig
@@ -454,20 +454,18 @@ fn selectJavaCommand(io: Io, allocator: mem.Allocator, env_map: *process.Environ
     return allocator.dupe(u8, "java");
 }
 
-const testing_io: Io = std.testing.io;
-
-fn writeTempFile(tmp_dir: std.testing.TmpDir, sub_path: []const u8, content: []const u8) !void {
-    const file = try tmp_dir.dir.createFile(testing_io, sub_path, .{});
-    defer file.close(testing_io);
+fn writeTempFile(io: Io, tmp_dir: std.testing.TmpDir, sub_path: []const u8, content: []const u8) !void {
+    const file = try tmp_dir.dir.createFile(io, sub_path, .{});
+    defer file.close(io);
     var buf: [4096]u8 = undefined;
-    var w = file.writer(testing_io, &buf);
+    var w = file.writer(io, &buf);
     try w.interface.writeAll(content);
     try w.interface.flush();
 }
 
-fn tmpDirPath(tmp_dir: std.testing.TmpDir, allocator: mem.Allocator, sub_path: []const u8) ![]u8 {
+fn tmpDirPath(io: Io, tmp_dir: std.testing.TmpDir, allocator: mem.Allocator, sub_path: []const u8) ![]u8 {
     var path_buf: [Io.Dir.max_path_bytes]u8 = undefined;
-    const len = tmp_dir.dir.realPath(testing_io, &path_buf) catch return error.BadPath;
+    const len = tmp_dir.dir.realPath(io, &path_buf) catch return error.BadPath;
     return std.fmt.allocPrint(allocator, "{s}/{s}", .{ path_buf[0..len], sub_path });
 }
 
@@ -476,9 +474,9 @@ test "readArgsFile: basic lines" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "test.conf", "-Xmx512m\n-Dfoo=bar\n");
+    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "-Xmx512m\n-Dfoo=bar\n");
 
-    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
     defer allocator.free(path);
 
     var list: ArrayList([]u8) = .empty;
@@ -487,7 +485,7 @@ test "readArgsFile: basic lines" {
         list.deinit(allocator);
     }
 
-    try readArgsFile(testing_io, allocator, path, &list);
+    try readArgsFile(std.testing.io, allocator, path, &list);
     try std.testing.expectEqual(@as(usize, 2), list.items.len);
     try std.testing.expectEqualStrings("-Xmx512m", list.items[0]);
     try std.testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
@@ -498,9 +496,9 @@ test "readArgsFile: skips comments and blank lines" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "test.conf", "# comment\n\n-Xmx256m\n  # indented comment\n-Dfoo=1\n");
+    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "# comment\n\n-Xmx256m\n  # indented comment\n-Dfoo=1\n");
 
-    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
     defer allocator.free(path);
 
     var list: ArrayList([]u8) = .empty;
@@ -509,7 +507,7 @@ test "readArgsFile: skips comments and blank lines" {
         list.deinit(allocator);
     }
 
-    try readArgsFile(testing_io, allocator, path, &list);
+    try readArgsFile(std.testing.io, allocator, path, &list);
     try std.testing.expectEqual(@as(usize, 2), list.items.len);
     try std.testing.expectEqualStrings("-Xmx256m", list.items[0]);
     try std.testing.expectEqualStrings("-Dfoo=1", list.items[1]);
@@ -520,9 +518,9 @@ test "readArgsFile: no trailing newline" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "test.conf", "-Xmx128m");
+    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "-Xmx128m");
 
-    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
     defer allocator.free(path);
 
     var list: ArrayList([]u8) = .empty;
@@ -531,7 +529,7 @@ test "readArgsFile: no trailing newline" {
         list.deinit(allocator);
     }
 
-    try readArgsFile(testing_io, allocator, path, &list);
+    try readArgsFile(std.testing.io, allocator, path, &list);
     try std.testing.expectEqual(@as(usize, 1), list.items.len);
     try std.testing.expectEqualStrings("-Xmx128m", list.items[0]);
 }
@@ -541,9 +539,9 @@ test "readArgsFile: empty file" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "test.conf", "");
+    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "");
 
-    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
     defer allocator.free(path);
 
     var list: ArrayList([]u8) = .empty;
@@ -552,7 +550,7 @@ test "readArgsFile: empty file" {
         list.deinit(allocator);
     }
 
-    try readArgsFile(testing_io, allocator, path, &list);
+    try readArgsFile(std.testing.io, allocator, path, &list);
     try std.testing.expectEqual(@as(usize, 0), list.items.len);
 }
 
@@ -561,9 +559,9 @@ test "readArgsFile: only comments" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "test.conf", "# comment 1\n# comment 2\n");
+    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "# comment 1\n# comment 2\n");
 
-    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
     defer allocator.free(path);
 
     var list: ArrayList([]u8) = .empty;
@@ -572,7 +570,7 @@ test "readArgsFile: only comments" {
         list.deinit(allocator);
     }
 
-    try readArgsFile(testing_io, allocator, path, &list);
+    try readArgsFile(std.testing.io, allocator, path, &list);
     try std.testing.expectEqual(@as(usize, 0), list.items.len);
 }
 
@@ -581,9 +579,9 @@ test "readArgsFile: trims whitespace" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "test.conf", "  -Xmx512m  \n\t-Dfoo=bar\t\n");
+    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "  -Xmx512m  \n\t-Dfoo=bar\t\n");
 
-    const path = try tmpDirPath(tmp_dir, allocator, "test.conf");
+    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
     defer allocator.free(path);
 
     var list: ArrayList([]u8) = .empty;
@@ -592,7 +590,7 @@ test "readArgsFile: trims whitespace" {
         list.deinit(allocator);
     }
 
-    try readArgsFile(testing_io, allocator, path, &list);
+    try readArgsFile(std.testing.io, allocator, path, &list);
     try std.testing.expectEqual(@as(usize, 2), list.items.len);
     try std.testing.expectEqualStrings("-Xmx512m", list.items[0]);
     try std.testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
@@ -602,16 +600,16 @@ test "resolveArgsFile: prefers user path" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "user.conf", "a");
-    try writeTempFile(tmp_dir, "template.conf", "b");
+    try writeTempFile(std.testing.io, tmp_dir, "user.conf", "a");
+    try writeTempFile(std.testing.io, tmp_dir, "template.conf", "b");
 
     const allocator = std.testing.allocator;
-    const user_path = try tmpDirPath(tmp_dir, allocator, "user.conf");
+    const user_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "user.conf");
     defer allocator.free(user_path);
-    const template_path = try tmpDirPath(tmp_dir, allocator, "template.conf");
+    const template_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "template.conf");
     defer allocator.free(template_path);
 
-    const result = resolveArgsFile(testing_io, user_path, template_path);
+    const result = resolveArgsFile(std.testing.io, user_path, template_path);
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings(user_path, result.?);
 }
@@ -620,21 +618,21 @@ test "resolveArgsFile: falls back to template" {
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    try writeTempFile(tmp_dir, "template.conf", "b");
+    try writeTempFile(std.testing.io, tmp_dir, "template.conf", "b");
 
     const allocator = std.testing.allocator;
-    const user_path = try tmpDirPath(tmp_dir, allocator, "user.conf");
+    const user_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "user.conf");
     defer allocator.free(user_path);
-    const template_path = try tmpDirPath(tmp_dir, allocator, "template.conf");
+    const template_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "template.conf");
     defer allocator.free(template_path);
 
-    const result = resolveArgsFile(testing_io, user_path, template_path);
+    const result = resolveArgsFile(std.testing.io, user_path, template_path);
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings(template_path, result.?);
 }
 
 test "resolveArgsFile: returns null when neither exists" {
-    const result = resolveArgsFile(testing_io, "/nonexistent/user.conf", "/nonexistent/template.conf");
+    const result = resolveArgsFile(std.testing.io, "/nonexistent/user.conf", "/nonexistent/template.conf");
     try std.testing.expect(result == null);
 }
 

--- a/launcher/src/main.zig
+++ b/launcher/src/main.zig
@@ -454,239 +454,6 @@ fn selectJavaCommand(io: Io, allocator: mem.Allocator, env_map: *process.Environ
     return allocator.dupe(u8, "java");
 }
 
-fn writeTempFile(io: Io, tmp_dir: std.testing.TmpDir, sub_path: []const u8, content: []const u8) !void {
-    const file = try tmp_dir.dir.createFile(io, sub_path, .{});
-    defer file.close(io);
-    var buf: [4096]u8 = undefined;
-    var w = file.writer(io, &buf);
-    try w.interface.writeAll(content);
-    try w.interface.flush();
-}
-
-fn tmpDirPath(io: Io, tmp_dir: std.testing.TmpDir, allocator: mem.Allocator, sub_path: []const u8) ![]u8 {
-    var path_buf: [Io.Dir.max_path_bytes]u8 = undefined;
-    const len = tmp_dir.dir.realPath(io, &path_buf) catch return error.BadPath;
-    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ path_buf[0..len], sub_path });
-}
-
-test "readArgsFile: basic lines" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "-Xmx512m\n-Dfoo=bar\n");
-
-    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
-    defer allocator.free(path);
-
-    var list: ArrayList([]u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    try readArgsFile(std.testing.io, allocator, path, &list);
-    try std.testing.expectEqual(@as(usize, 2), list.items.len);
-    try std.testing.expectEqualStrings("-Xmx512m", list.items[0]);
-    try std.testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
-}
-
-test "readArgsFile: skips comments and blank lines" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "# comment\n\n-Xmx256m\n  # indented comment\n-Dfoo=1\n");
-
-    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
-    defer allocator.free(path);
-
-    var list: ArrayList([]u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    try readArgsFile(std.testing.io, allocator, path, &list);
-    try std.testing.expectEqual(@as(usize, 2), list.items.len);
-    try std.testing.expectEqualStrings("-Xmx256m", list.items[0]);
-    try std.testing.expectEqualStrings("-Dfoo=1", list.items[1]);
-}
-
-test "readArgsFile: no trailing newline" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "-Xmx128m");
-
-    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
-    defer allocator.free(path);
-
-    var list: ArrayList([]u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    try readArgsFile(std.testing.io, allocator, path, &list);
-    try std.testing.expectEqual(@as(usize, 1), list.items.len);
-    try std.testing.expectEqualStrings("-Xmx128m", list.items[0]);
-}
-
-test "readArgsFile: empty file" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "");
-
-    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
-    defer allocator.free(path);
-
-    var list: ArrayList([]u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    try readArgsFile(std.testing.io, allocator, path, &list);
-    try std.testing.expectEqual(@as(usize, 0), list.items.len);
-}
-
-test "readArgsFile: only comments" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "# comment 1\n# comment 2\n");
-
-    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
-    defer allocator.free(path);
-
-    var list: ArrayList([]u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    try readArgsFile(std.testing.io, allocator, path, &list);
-    try std.testing.expectEqual(@as(usize, 0), list.items.len);
-}
-
-test "readArgsFile: trims whitespace" {
-    const allocator = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "test.conf", "  -Xmx512m  \n\t-Dfoo=bar\t\n");
-
-    const path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "test.conf");
-    defer allocator.free(path);
-
-    var list: ArrayList([]u8) = .empty;
-    defer {
-        for (list.items) |item| allocator.free(item);
-        list.deinit(allocator);
-    }
-
-    try readArgsFile(std.testing.io, allocator, path, &list);
-    try std.testing.expectEqual(@as(usize, 2), list.items.len);
-    try std.testing.expectEqualStrings("-Xmx512m", list.items[0]);
-    try std.testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
-}
-
-test "resolveArgsFile: prefers user path" {
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "user.conf", "a");
-    try writeTempFile(std.testing.io, tmp_dir, "template.conf", "b");
-
-    const allocator = std.testing.allocator;
-    const user_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "user.conf");
-    defer allocator.free(user_path);
-    const template_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "template.conf");
-    defer allocator.free(template_path);
-
-    const result = resolveArgsFile(std.testing.io, user_path, template_path);
-    try std.testing.expect(result != null);
-    try std.testing.expectEqualStrings(user_path, result.?);
-}
-
-test "resolveArgsFile: falls back to template" {
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try writeTempFile(std.testing.io, tmp_dir, "template.conf", "b");
-
-    const allocator = std.testing.allocator;
-    const user_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "user.conf");
-    defer allocator.free(user_path);
-    const template_path = try tmpDirPath(std.testing.io, tmp_dir, allocator, "template.conf");
-    defer allocator.free(template_path);
-
-    const result = resolveArgsFile(std.testing.io, user_path, template_path);
-    try std.testing.expect(result != null);
-    try std.testing.expectEqualStrings(template_path, result.?);
-}
-
-test "resolveArgsFile: returns null when neither exists" {
-    const result = resolveArgsFile(std.testing.io, "/nonexistent/user.conf", "/nonexistent/template.conf");
-    try std.testing.expect(result == null);
-}
-
-test "resolveConfigBase: linux uses XDG_CONFIG_HOME" {
-    if (native_os != .linux) return error.SkipZigTest;
-
-    const allocator = std.testing.allocator;
-    var env_map: process.Environ.Map = .init(allocator);
-    defer env_map.deinit();
-    try env_map.put("XDG_CONFIG_HOME", "/custom/config");
-
-    const result = try resolveConfigBase(allocator, &env_map);
-    defer allocator.free(result);
-    try std.testing.expectEqualStrings("/custom/config", result);
-}
-
-test "resolveConfigBase: linux falls back to HOME/.config" {
-    if (native_os != .linux) return error.SkipZigTest;
-
-    const allocator = std.testing.allocator;
-    var env_map: process.Environ.Map = .init(allocator);
-    defer env_map.deinit();
-    try env_map.put("HOME", "/home/testuser");
-
-    const result = try resolveConfigBase(allocator, &env_map);
-    defer allocator.free(result);
-    try std.testing.expectEqualStrings("/home/testuser/.config", result);
-}
-
-test "resolveUserHome: missing HOME returns error" {
-    const allocator = std.testing.allocator;
-    var env_map: process.Environ.Map = .init(allocator);
-    defer env_map.deinit();
-
-    const result = resolveUserHome(allocator, &env_map);
-    try std.testing.expectError(error.MissingHome, result);
-}
-
-test "resolveUserConfigPaths: produces expected paths" {
-    if (native_os != .linux) return error.SkipZigTest;
-
-    const allocator = std.testing.allocator;
-    var env_map: process.Environ.Map = .init(allocator);
-    defer env_map.deinit();
-    try env_map.put("XDG_CONFIG_HOME", "/tmp/testconfig");
-
-    const paths = try resolveUserConfigPaths(allocator, &env_map);
-    defer allocator.free(paths.java_opts_path);
-    defer allocator.free(paths.app_args_path);
-
-    try std.testing.expectEqualStrings("/tmp/testconfig/husi/desktop-java-opts.conf", paths.java_opts_path);
-    try std.testing.expectEqualStrings("/tmp/testconfig/husi/desktop-app-args.conf", paths.app_args_path);
-}
-
 pub fn main(init: std.process.Init) !u8 {
     const io = init.io;
     const arena = init.arena;
@@ -783,4 +550,249 @@ pub fn main(init: std.process.Init) !u8 {
             },
         }
     }
+}
+
+const testing = std.testing;
+const TmpDir = testing.TmpDir;
+
+fn writeTempFile(io: Io, tmp_dir: TmpDir, sub_path: []const u8, content: []const u8) !void {
+    const file = try tmp_dir.dir.createFile(io, sub_path, .{});
+    defer file.close(io);
+    var buf: [4096]u8 = undefined;
+    var writer = file.writer(io, &buf);
+    try writer.interface.writeAll(content);
+    try writer.interface.flush();
+}
+
+fn tmpDirPath(io: Io, tmp_dir: TmpDir, allocator: mem.Allocator, sub_path: []const u8) ![]u8 {
+    var path_buf: [Io.Dir.max_path_bytes]u8 = undefined;
+    const len = tmp_dir.dir.realPath(io, &path_buf) catch return error.BadPath;
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ path_buf[0..len], sub_path });
+}
+
+test "readArgsFile: basic lines" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "test.conf", "-Xmx512m\n-Dfoo=bar\n");
+
+    const path = try tmpDirPath(io, tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(io, allocator, path, &list);
+    try testing.expectEqual(@as(usize, 2), list.items.len);
+    try testing.expectEqualStrings("-Xmx512m", list.items[0]);
+    try testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
+}
+
+test "readArgsFile: skips comments and blank lines" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "test.conf", "# comment\n\n-Xmx256m\n  # indented comment\n-Dfoo=1\n");
+
+    const path = try tmpDirPath(io, tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(io, allocator, path, &list);
+    try testing.expectEqual(@as(usize, 2), list.items.len);
+    try testing.expectEqualStrings("-Xmx256m", list.items[0]);
+    try testing.expectEqualStrings("-Dfoo=1", list.items[1]);
+}
+
+test "readArgsFile: no trailing newline" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "test.conf", "-Xmx128m");
+
+    const path = try tmpDirPath(io, tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(io, allocator, path, &list);
+    try testing.expectEqual(@as(usize, 1), list.items.len);
+    try testing.expectEqualStrings("-Xmx128m", list.items[0]);
+}
+
+test "readArgsFile: empty file" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "test.conf", "");
+
+    const path = try tmpDirPath(io, tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(io, allocator, path, &list);
+    try testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "readArgsFile: only comments" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "test.conf", "# comment 1\n# comment 2\n");
+
+    const path = try tmpDirPath(io, tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(io, allocator, path, &list);
+    try testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "readArgsFile: trims whitespace" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "test.conf", "  -Xmx512m  \n\t-Dfoo=bar\t\n");
+
+    const path = try tmpDirPath(io, tmp_dir, allocator, "test.conf");
+    defer allocator.free(path);
+
+    var list: ArrayList([]u8) = .empty;
+    defer {
+        for (list.items) |item| allocator.free(item);
+        list.deinit(allocator);
+    }
+
+    try readArgsFile(testing.io, allocator, path, &list);
+    try testing.expectEqual(@as(usize, 2), list.items.len);
+    try testing.expectEqualStrings("-Xmx512m", list.items[0]);
+    try testing.expectEqualStrings("-Dfoo=bar", list.items[1]);
+}
+
+test "resolveArgsFile: prefers user path" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "user.conf", "a");
+    try writeTempFile(io, tmp_dir, "template.conf", "b");
+
+    const user_path = try tmpDirPath(io, tmp_dir, allocator, "user.conf");
+    defer allocator.free(user_path);
+    const template_path = try tmpDirPath(io, tmp_dir, allocator, "template.conf");
+    defer allocator.free(template_path);
+
+    const result = resolveArgsFile(io, user_path, template_path);
+    try testing.expect(result != null);
+    try testing.expectEqualStrings(user_path, result.?);
+}
+
+test "resolveArgsFile: falls back to template" {
+    const allocator = testing.allocator;
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try writeTempFile(io, tmp_dir, "template.conf", "b");
+
+    const user_path = try tmpDirPath(io, tmp_dir, allocator, "user.conf");
+    defer allocator.free(user_path);
+    const template_path = try tmpDirPath(io, tmp_dir, allocator, "template.conf");
+    defer allocator.free(template_path);
+
+    const result = resolveArgsFile(io, user_path, template_path);
+    try testing.expect(result != null);
+    try testing.expectEqualStrings(template_path, result.?);
+}
+
+test "resolveArgsFile: returns null when neither exists" {
+    const io = testing.io;
+    const result = resolveArgsFile(io, "/nonexistent/user.conf", "/nonexistent/template.conf");
+    try testing.expect(result == null);
+}
+
+test "resolveConfigBase: linux uses XDG_CONFIG_HOME" {
+    if (native_os != .linux) return error.SkipZigTest;
+
+    const allocator = testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+    try env_map.put("XDG_CONFIG_HOME", "/custom/config");
+
+    const result = try resolveConfigBase(allocator, &env_map);
+    defer allocator.free(result);
+    try testing.expectEqualStrings("/custom/config", result);
+}
+
+test "resolveConfigBase: linux falls back to HOME/.config" {
+    if (native_os != .linux) return error.SkipZigTest;
+
+    const allocator = testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+    try env_map.put("HOME", "/home/testuser");
+
+    const result = try resolveConfigBase(allocator, &env_map);
+    defer allocator.free(result);
+    try testing.expectEqualStrings("/home/testuser/.config", result);
+}
+
+test "resolveUserHome: missing HOME returns error" {
+    const allocator = testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+
+    const result = resolveUserHome(allocator, &env_map);
+    try testing.expectError(error.MissingHome, result);
+}
+
+test "resolveUserConfigPaths: produces expected paths" {
+    if (native_os != .linux) return error.SkipZigTest;
+
+    const allocator = testing.allocator;
+    var env_map: process.Environ.Map = .init(allocator);
+    defer env_map.deinit();
+    try env_map.put("XDG_CONFIG_HOME", "/tmp/testconfig");
+
+    const paths = try resolveUserConfigPaths(allocator, &env_map);
+    defer allocator.free(paths.java_opts_path);
+    defer allocator.free(paths.app_args_path);
+
+    try testing.expectEqualStrings("/tmp/testconfig/husi/desktop-java-opts.conf", paths.java_opts_path);
+    try testing.expectEqualStrings("/tmp/testconfig/husi/desktop-app-args.conf", paths.app_args_path);
 }


### PR DESCRIPTION
## Summary

- Add 13 Zig unit tests for the launcher's core logic in `launcher/src/main.zig`
- Add `make test_launcher` target and include it in `make test`
- Add CI step in `test.yml` to run launcher tests, triggered on `launcher/**` changes
- Update `AGENTS.md` to document the new test target

## Test coverage

| Function | Tests | What's covered |
|---|---|---|
| `readArgsFile` | 6 | Basic parsing, comment/blank line skipping, no trailing newline, empty file, comment-only file, whitespace trimming |
| `resolveArgsFile` | 3 | User path priority, template fallback, null when neither exists |
| `resolveConfigBase` | 2 | `XDG_CONFIG_HOME` priority, `HOME/.config` fallback (Linux) |
| `resolveUserHome` | 1 | Missing `HOME` returns error |
| `resolveUserConfigPaths` | 1 | Expected path construction (Linux) |

## Test plan

- [x] All 13 tests pass locally with `zig build test` (Zig 0.16.0)
- [x] `make test_launcher` works
- [ ] CI runs launcher tests on push/PR touching `launcher/**`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5prGjMiKzjjhADzD8LLL)_