### PR TITLE
Make proxy cards of a grid row share the same height

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -336,7 +336,9 @@ private fun ProxyCard(
 ) {
     Card(
         onClick = select,
-        modifier = modifier.fillMaxWidth(),
+        // The grid measures its items with the row height as the maximum, so filling the size
+        // stretches the shorter cards of a row up to the tallest one.
+        modifier = modifier.fillMaxSize(),
         enabled = selectable,
         shape = CardDefaults.elevatedShape,
         colors = CardDefaults.elevatedCardColors(),
@@ -352,9 +354,8 @@ private fun ProxyCard(
     ) {
         Row(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.Bottom,
         ) {
             if (selected) {
                 Box(
@@ -381,6 +382,7 @@ private fun ProxyCard(
                 )
             }
             ItemURLTestButton(
+                modifier = Modifier.align(Alignment.Bottom),
                 delay = proxy.urlTestDelay,
                 onClick = urlTest,
             )


### PR DESCRIPTION
## Problem

In the dashboard proxy set grid, cards in the same row could have different heights (a longer tag wraps to two lines), so short cards left a visible gap next to tall ones.

## Change

`Grid` measures each item with loose constraints whose `maxHeight` is the resolved row height, so a child that fills the height is stretched up to the tallest card of its row:

- `ProxyCard` now uses `Modifier.fillMaxSize()` instead of `fillMaxWidth()`.
- Its inner `Row` fills the size too, so the "selected" indicator bar spans the whole card.
- The row no longer bottom-aligns everything; the type/tag column stays at the top and only `ItemURLTestButton` keeps `Alignment.Bottom`, which lines the delay chips up across the row.

Row heights are still derived from the items' intrinsic heights, so the natural card size is unchanged — only the shorter card grows.

## Testing

`./gradlew :composeApp:compileKotlinDesktop` — passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kin63JVuHRFpY4S2oi5N9z)_