### PR TITLE
fix(dashboard): restyle speed test button to use theme colors

### DIFF
--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -351,37 +351,38 @@ private fun ProxyCard(
             },
         ),
     ) {
-        Row(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         ) {
-            if (selected) {
-                Box(
-                    modifier = Modifier
-                        .width(4.dp)
-                        .fillMaxHeight()
-                        .background(MaterialTheme.colorScheme.primary),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-            }
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = proxy.type,
-                    color = MaterialTheme.colorScheme.secondary,
-                    style = MaterialTheme.typography.titleSmallEmphasized,
-                )
-                Text(
-                    text = proxy.tag,
-                    color = MaterialTheme.colorScheme.tertiary,
-                    style = MaterialTheme.typography.bodyMediumEmphasized,
-                )
+            Row {
+                if (selected) {
+                    Box(
+                        modifier = Modifier
+                            .width(4.dp)
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.primary),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = proxy.type,
+                        color = MaterialTheme.colorScheme.secondary,
+                        style = MaterialTheme.typography.titleSmallEmphasized,
+                    )
+                    Text(
+                        text = proxy.tag,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        style = MaterialTheme.typography.bodyMediumEmphasized,
+                    )
+                }
             }
             ItemURLTestButton(
-                modifier = Modifier.align(Alignment.Bottom),
+                modifier = Modifier.align(Alignment.BottomEnd),
                 delay = proxy.urlTestDelay,
                 onClick = urlTest,
             )

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -351,41 +351,39 @@ private fun ProxyCard(
             },
         ),
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(start = 16.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         ) {
-            if (selected) {
-                Box(
-                    modifier = Modifier
-                        .width(4.dp)
-                        .fillMaxHeight()
-                        .background(MaterialTheme.colorScheme.primary),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
+            Row {
+                if (selected) {
+                    Box(
+                        modifier = Modifier
+                            .width(4.dp)
+                            .fillMaxHeight()
+                            .background(MaterialTheme.colorScheme.primary),
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = proxy.type,
+                        color = MaterialTheme.colorScheme.secondary,
+                        style = MaterialTheme.typography.titleSmallEmphasized,
+                    )
+                    Text(
+                        text = proxy.tag,
+                        color = MaterialTheme.colorScheme.tertiary,
+                        style = MaterialTheme.typography.bodyMediumEmphasized,
+                    )
+                }
             }
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .padding(vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Text(
-                    text = proxy.type,
-                    color = MaterialTheme.colorScheme.secondary,
-                    style = MaterialTheme.typography.titleSmallEmphasized,
-                )
-                Text(
-                    text = proxy.tag,
-                    color = MaterialTheme.colorScheme.tertiary,
-                    style = MaterialTheme.typography.bodyMediumEmphasized,
-                )
-            }
+            Spacer(modifier = Modifier.weight(1f))
             ItemURLTestButton(
-                modifier = Modifier
-                    .align(Alignment.Bottom)
-                    .padding(end = 16.dp, bottom = 12.dp),
+                modifier = Modifier.align(Alignment.End),
                 delay = proxy.urlTestDelay,
                 onClick = urlTest,
             )

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -351,38 +351,41 @@ private fun ProxyCard(
             },
         ),
     ) {
-        Box(
+        Row(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(start = 16.dp),
         ) {
-            Row {
-                if (selected) {
-                    Box(
-                        modifier = Modifier
-                            .width(4.dp)
-                            .fillMaxHeight()
-                            .background(MaterialTheme.colorScheme.primary),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        text = proxy.type,
-                        color = MaterialTheme.colorScheme.secondary,
-                        style = MaterialTheme.typography.titleSmallEmphasized,
-                    )
-                    Text(
-                        text = proxy.tag,
-                        color = MaterialTheme.colorScheme.tertiary,
-                        style = MaterialTheme.typography.bodyMediumEmphasized,
-                    )
-                }
+            if (selected) {
+                Box(
+                    modifier = Modifier
+                        .width(4.dp)
+                        .fillMaxHeight()
+                        .background(MaterialTheme.colorScheme.primary),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = proxy.type,
+                    color = MaterialTheme.colorScheme.secondary,
+                    style = MaterialTheme.typography.titleSmallEmphasized,
+                )
+                Text(
+                    text = proxy.tag,
+                    color = MaterialTheme.colorScheme.tertiary,
+                    style = MaterialTheme.typography.bodyMediumEmphasized,
+                )
             }
             ItemURLTestButton(
-                modifier = Modifier.align(Alignment.BottomEnd),
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .padding(end = 16.dp, bottom = 12.dp),
                 delay = proxy.urlTestDelay,
                 onClick = urlTest,
             )

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/dashboard/DashboardProxySet.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastCoerceAtLeast
@@ -396,13 +395,25 @@ private fun ItemURLTestButton(
     delay: Int,
     onClick: () -> Unit,
 ) {
+    val delayColor = colorForUrlTestDelay(delay)
     Surface(
         modifier = modifier
             .width(56.dp)
             .clickable { onClick() },
         shape = RoundedCornerShape(50),
-        color = Color.Black,
-        shadowElevation = 6.dp,
+        color = if (delay > 0) {
+            delayColor.copy(alpha = 0.12f)
+        } else {
+            MaterialTheme.colorScheme.secondaryContainer
+        },
+        border = BorderStroke(
+            1.dp,
+            if (delay > 0) {
+                delayColor.copy(alpha = 0.3f)
+            } else {
+                MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+            },
+        ),
     ) {
         Box(
             modifier = Modifier
@@ -413,12 +424,14 @@ private fun ItemURLTestButton(
             if (delay > 0) {
                 Text(
                     text = delay.toString(),
-                    color = colorForUrlTestDelay(delay),
+                    color = delayColor,
+                    style = MaterialTheme.typography.labelMedium,
                 )
             } else {
                 Icon(
                     vectorResource(Res.drawable.bolt),
                     stringResource(Res.string.connection_test),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
             }
         }


### PR DESCRIPTION
## Summary

- Replace hardcoded `Color.Black` background on the speed test button (`ItemURLTestButton`) with theme-aware styling
- When showing latency: use a tinted background based on the delay color (green/orange/red at 12% opacity) with a matching subtle border
- When idle (no delay): use `secondaryContainer` background with proper `onSecondaryContainer` icon tint
- Add `labelMedium` typography to the delay text for consistent sizing

## Before / After

**Before:** The button used `Color.Black` with `shadowElevation`, appearing as a solid dark blob regardless of theme — especially jarring in light mode.

**After:** The button adapts to the theme and reflects the connection quality through its background tint, blending naturally with the surrounding Material 3 card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yapedp1G1thA8T17KDJuMx)_