### PR TITLE
feat(plugin): show not installed plugins

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -764,6 +764,8 @@
     <string name="tun_strict_route">Tun 严格路由</string>
     <string name="tun_auto_redirect">Tun 自动重定向</string>
     <string name="no_plugin_found">没有找到任何插件！</string>
+    <string name="plugin_not_installed">未安装</string>
+    <string name="plugin_not_installed_summary">点击下载并安装</string>
     <string name="traffic_pattern">流量模式</string>
     <string name="route_invert">反转匹配</string>
     <string name="latency">延迟</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -765,7 +765,7 @@
     <string name="tun_auto_redirect">Tun 自动重定向</string>
     <string name="no_plugin_found">没有找到任何插件！</string>
     <string name="plugin_not_installed">未安装</string>
-    <string name="plugin_not_installed_summary">点击下载并安装</string>
+    <string name="plugin_not_installed_summary">点击打开下载页面</string>
     <string name="traffic_pattern">流量模式</string>
     <string name="route_invert">反转匹配</string>
     <string name="latency">延迟</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -875,6 +875,8 @@
     <string name="tun_strict_route">Tun strict route</string>
     <string name="tun_auto_redirect">Tun auto redirect</string>
     <string name="no_plugin_found">No plugin found!</string>
+    <string name="plugin_not_installed">Not installed</string>
+    <string name="plugin_not_installed_summary">Tap to download and install</string>
     <string name="traffic_pattern">Traffic Pattern</string>
     <string name="route_invert">Invert Match</string>
     <string name="latency">Latency</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -876,7 +876,7 @@
     <string name="tun_auto_redirect">Tun auto redirect</string>
     <string name="no_plugin_found">No plugin found!</string>
     <string name="plugin_not_installed">Not installed</string>
-    <string name="plugin_not_installed_summary">Tap to download and install</string>
+    <string name="plugin_not_installed_summary">Tap to open the download page</string>
     <string name="traffic_pattern">Traffic Pattern</string>
     <string name="route_invert">Invert Match</string>
     <string name="latency">Latency</string>

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/PluginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/PluginScreen.kt
@@ -36,13 +36,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.husi.compose.BoxedVerticalScrollbar
-import fr.husi.compose.collectAsStateWithLifecycle
 import fr.husi.compose.IconMaskColors
 import fr.husi.compose.MaskedIcon
-import fr.husi.compose.platformCombinedClickable
 import fr.husi.compose.SimpleIconButton
 import fr.husi.compose.SimpleTopAppBar
+import fr.husi.compose.collectAsStateWithLifecycle
 import fr.husi.compose.material3.Text
+import fr.husi.compose.platformCombinedClickable
 import fr.husi.compose.withNavigation
 import fr.husi.database.DataStore
 import fr.husi.fmt.PluginEntry

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/PluginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/PluginScreen.kt
@@ -84,7 +84,6 @@ fun PluginScreen(
     val isExpert by DataStore.isExpert.collectAsStateWithLifecycle()
 
     val notInstalledPlugins = remember(plugins) {
-        if (!PlatformInfo.isAndroid) return@remember emptyList<PluginEntry>()
         val installedIDs = plugins.mapTo(mutableSetOf()) { it.id }
         enumEntries<PluginEntry>().filter { it.pluginId !in installedIDs }
     }
@@ -131,7 +130,7 @@ fun PluginScreen(
                 ) {
                     installedPlugins(plugins, openPluginCard, uriHandler::openUri)
                     notInstalledPlugins(notInstalledPlugins) {
-                        uriHandler.openUri(it.downloadSource.apk)
+                        uriHandler.openUri(it.platformDownloadUri)
                     }
                     platformPluginPreferences(isExpert, ::needRestart)
                 }
@@ -184,15 +183,7 @@ private fun LazyListScope.installedPlugins(
                             description = "v${plugin.version}",
                             onClick = { openPluginCard(plugin) },
                             onLongClick = {
-                                plugin.entry?.let {
-                                    openUri(
-                                        if (PlatformInfo.isAndroid) {
-                                            it.downloadSource.apk
-                                        } else {
-                                            it.downloadSource.binary
-                                        },
-                                    )
-                                }
+                                plugin.entry?.let { openUri(it.platformDownloadUri) }
                             },
                         )
                     }
@@ -215,9 +206,12 @@ private fun LazyListScope.installedPlugins(
     }
 }
 
+private val PluginEntry.platformDownloadUri: String
+    get() = if (PlatformInfo.isAndroid) downloadSource.apk else downloadSource.binary
+
 private fun LazyListScope.notInstalledPlugins(
     plugins: List<PluginEntry>,
-    onInstall: (PluginEntry) -> Unit,
+    onDownload: (PluginEntry) -> Unit,
 ) {
     if (plugins.isEmpty()) return
     item("not_installed_plugins_card") {
@@ -247,7 +241,7 @@ private fun LazyListScope.notInstalledPlugins(
                         },
                         title = stringResource(plugin.displayName),
                         description = stringResource(Res.string.plugin_not_installed_summary),
-                        onClick = { onInstall(plugin) },
+                        onClick = { onDownload(plugin) },
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/fr/husi/ui/PluginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/fr/husi/ui/PluginScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -44,22 +45,27 @@ import fr.husi.compose.SimpleTopAppBar
 import fr.husi.compose.material3.Text
 import fr.husi.compose.withNavigation
 import fr.husi.database.DataStore
+import fr.husi.fmt.PluginEntry
 import fr.husi.ktx.restartApplication
 import fr.husi.platform.PlatformInfo
 import fr.husi.resources.Res
 import fr.husi.resources.arrow_back
 import fr.husi.resources.back
+import fr.husi.resources.download
 import fr.husi.resources.need_restart
 import fr.husi.resources.nfc
 import fr.husi.resources.no_plugin_found
 import fr.husi.resources.ok
 import fr.husi.resources.plugin
+import fr.husi.resources.plugin_not_installed
+import fr.husi.resources.plugin_not_installed_summary
 import fr.husi.resources.version_x
 import io.github.oikvpqya.compose.fastscroller.material3.defaultMaterialScrollbarStyle
 import io.github.oikvpqya.compose.fastscroller.rememberScrollbarAdapter
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
+import kotlin.enums.enumEntries
 
 @Composable
 fun PluginScreen(
@@ -76,6 +82,12 @@ fun PluginScreen(
     val openPluginCard = rememberOpenPluginCard()
 
     val isExpert by DataStore.isExpert.collectAsStateWithLifecycle()
+
+    val notInstalledPlugins = remember(plugins) {
+        if (!PlatformInfo.isAndroid) return@remember emptyList<PluginEntry>()
+        val installedIDs = plugins.mapTo(mutableSetOf()) { it.id }
+        enumEntries<PluginEntry>().filter { it.pluginId !in installedIDs }
+    }
 
     fun needRestart() {
         snackbar.show(
@@ -118,6 +130,9 @@ fun PluginScreen(
                     contentPadding = contentPadding,
                 ) {
                     installedPlugins(plugins, openPluginCard, uriHandler::openUri)
+                    notInstalledPlugins(notInstalledPlugins) {
+                        uriHandler.openUri(it.downloadSource.apk)
+                    }
                     platformPluginPreferences(isExpert, ::needRestart)
                 }
 
@@ -200,6 +215,45 @@ private fun LazyListScope.installedPlugins(
     }
 }
 
+private fun LazyListScope.notInstalledPlugins(
+    plugins: List<PluginEntry>,
+    onInstall: (PluginEntry) -> Unit,
+) {
+    if (plugins.isEmpty()) return
+    item("not_installed_plugins_card") {
+        OutlinedCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(Res.string.plugin_not_installed),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                for (plugin in plugins) {
+                    PluginCardItem(
+                        icon = {
+                            MaskedIcon(
+                                Res.drawable.download,
+                                color = IconMaskColors.IconLightGreen,
+                            )
+                        },
+                        title = stringResource(plugin.displayName),
+                        description = stringResource(Res.string.plugin_not_installed_summary),
+                        onClick = { onInstall(plugin) },
+                    )
+                }
+            }
+        }
+    }
+}
 
 @Composable
 private fun PluginCardItem(

--- a/libcore/log_test.go
+++ b/libcore/log_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	F "github.com/sagernet/sing/common/format"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/proto/daemon/started_service.proto
+++ b/proto/daemon/started_service.proto
@@ -1,4 +1,4 @@
-// Vendored from github.com/sagernet/sing-box v1.15.0-alpha.1 by `make proto`.
+// Vendored from github.com/sagernet/sing-box v1.15.0-alpha.2 by `make proto`.
 // Trimmed to the RPCs husi actually calls; the rest of the upstream
 // schema is not copied.
 // Do not edit: husi is wire compatible with sing-box here, so every


### PR DESCRIPTION
The plugin screen only listed plugins that were already installed, so the remaining ones were not discoverable from inside the app.

## Changes

- `PluginScreen.kt`: a second `OutlinedCard` lists every `PluginEntry` whose `pluginId` is not among the installed ones. Tapping a row opens that plugin's download page through `LocalUriHandler` — the APK page on Android, the binary page on desktop. The card is skipped entirely when nothing is missing.
- Desktop already lists every known plugin as a path row, but nothing there led to where the binary can be downloaded; the path rows stay the place to point at the file once it is downloaded.
- The Android/desktop download-source choice was written out twice, so it is now one `PluginEntry.platformDownloadUri` property used by both the installed rows' long click and the new card.
- New strings `plugin_not_installed` / `plugin_not_installed_summary`, with zh-rCN translations.

## CI fixes carried along

CI was already red on `dev` before this PR, and both failures aborted before the Kotlin was ever compiled, so the fixes are included here:

- `proto/daemon/started_service.proto`: `1eb014b` bumped sing-box to `v1.15.0-alpha.2` without re-running `make proto`, so the vendored header still named alpha.1 and the `test` job failed at its freshness gate. Regenerated with `make proto` — only the header line changes, the gRPC stubs are untouched.
- `libcore/log_test.go`: the sagernet import shared a group with testify, which gci rejects under `libcore/.golangci.yml`. Reformatted with `make fmt_go`.

Both files are tool output, not hand edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7Em7eSFdGoGsipM17Lpur